### PR TITLE
Incl. option to use regional climate forcing

### DIFF
--- a/src_dev/SMB_module.f90
+++ b/src_dev/SMB_module.f90
@@ -90,6 +90,12 @@ CONTAINS
   ! =======================================================
     
     ! Run the selected SMB model
+    ! If C%choice_forcing_method == 'SMB_direct', SMB is directly given, no need for a calculation
+    IF (C%choice_forcing_method == 'SMB_direct' ) THEN 
+      CALL sync
+      RETURN
+    END IF
+
     IF     (C%choice_SMB_model == 'uniform') THEN
       SMB%SMB_year( :,grid%i1:grid%i2) = C%SMB_uniform
       CALL sync

--- a/src_dev/configuration_module.f90
+++ b/src_dev/configuration_module.f90
@@ -253,6 +253,8 @@ MODULE configuration_module
   ! 'SMB_direct'           : Obtain SMB directly from a forcing file
   ! 'climate direct'       : Obtain temperature and precipitation (to be used in the ITM SMB model) directly from a forcing file
   CHARACTER(LEN=256)  :: choice_forcing_method_config            = 'd18O_inverse_dT_glob'
+  CHARACTER(LEN=256)  :: domain_climate_forcing_config           = 'global'                         ! The climate forcing file either covers the entire globe on a regular lon-lat grid, or only a region on an x-y grid.
+                                                                                                    ! Only used if choice_forcing_method_config = 'SMB_direct' or 'climate_direct' 
   
   REAL(dp)            :: dT_deepwater_averaging_window_config    = 3000                             ! Time window (in yr) over which global mean temperature anomaly is averaged to find the deep-water temperature anomaly
   REAL(dp)            :: dT_deepwater_dT_surf_ratio_config       = 0.25_dp                          ! Ratio between global mean surface temperature change and deep-water temperature change
@@ -646,6 +648,7 @@ MODULE configuration_module
     ! =======
     
     CHARACTER(LEN=256)                  :: choice_forcing_method
+    CHARACTER(LEN=256)                  :: domain_climate_forcing
     
     REAL(dp)                            :: dT_deepwater_averaging_window
     REAL(dp)                            :: dT_deepwater_dT_surf_ratio
@@ -1206,6 +1209,7 @@ CONTAINS
                      ocean_temperature_warm_config,              &
                      constant_lapserate_config,                  &
                      choice_forcing_method_config,               &
+                     domain_climate_forcing_config,              &                  
                      dT_deepwater_averaging_window_config,       &
                      dT_deepwater_dT_surf_ratio_config,          &
                      d18O_dT_deepwater_ratio_config,             &
@@ -1578,6 +1582,7 @@ CONTAINS
     ! =======
     
     C%choice_forcing_method               = choice_forcing_method_config
+    C%domain_climate_forcing              = domain_climate_forcing_config
     
     C%dT_deepwater_averaging_window       = dT_deepwater_averaging_window_config
     C%dT_deepwater_dT_surf_ratio          = dT_deepwater_dT_surf_ratio_config

--- a/src_dev/data_types_module.f90
+++ b/src_dev/data_types_module.f90
@@ -692,26 +692,24 @@ MODULE data_types_module
     
     ! External forcing: geothermal heat flux
     TYPE(type_netcdf_geothermal_heat_flux)  :: netcdf_ghf
-    INTEGER,                    POINTER     :: ghf_nlon
-    INTEGER,                    POINTER     :: ghf_nlat
-    REAL(dp), DIMENSION(:    ), POINTER     :: ghf_lon
-    REAL(dp), DIMENSION(:    ), POINTER     :: ghf_lat
+    INTEGER,                    POINTER     :: ghf_nlon, ghf_nlat
+    REAL(dp), DIMENSION(:    ), POINTER     :: ghf_lon, ghf_lat
     REAL(dp), DIMENSION(:,:  ), POINTER     :: ghf_ghf
     INTEGER :: wghf_nlon, wghf_nlat, wghf_lon, wghf_lat, wghf_ghf
 
     ! External forcing: climate forcing data
     TYPE(type_netcdf_climate_forcing)       :: netcdf_clim
-    INTEGER,                    POINTER     :: clim_nlon
-    INTEGER,                    POINTER     :: clim_nlat
+    INTEGER,                    POINTER     :: clim_nlon, clim_nlat
+    INTEGER,                    POINTER     :: clim_nx, clim_ny
     INTEGER,                    POINTER     :: clim_nyears
-    REAL(dp), DIMENSION(:    ), POINTER     :: clim_lon
-    REAL(dp), DIMENSION(:    ), POINTER     :: clim_lat
+    REAL(dp), DIMENSION(:    ), POINTER     :: clim_lon, clim_lat
+    REAL(dp), DIMENSION(:    ), POINTER     :: clim_x, clim_y
     REAL(dp), DIMENSION(:    ), POINTER     :: clim_time
     REAL(dp),                   POINTER     :: clim_t0, clim_t1
     REAL(dp), DIMENSION(:,:,:), POINTER     :: clim_T2m0, clim_T2m1, clim_T2m2, clim_Precip0, clim_Precip1, clim_Precip2  ! Monthly
     REAL(dp), DIMENSION(:,:  ), POINTER     :: clim_SMB0, clim_SMB1, clim_SMB2                                            ! Yearly
     INTEGER :: wclim_nyears, wclim_nlat, wclim_nlon, wclim_time, wclim_lat, wclim_lon, wclim_t0, wclim_t1, wclim_T2m0, wclim_T2m1, wclim_T2m2
-    INTEGER :: wclim_Precip0, wclim_Precip1, wclim_Precip2, wclim_SMB0, wclim_SMB1, wclim_SMB2
+    INTEGER :: wclim_Precip0, wclim_Precip1, wclim_Precip2, wclim_SMB0, wclim_SMB1, wclim_SMB2, wclim_nx, wclim_ny, wclim_x, wclim_y
     
   END TYPE type_forcing_data
   

--- a/src_dev/data_types_netcdf_module.f90
+++ b/src_dev/data_types_netcdf_module.f90
@@ -709,17 +709,23 @@ MODULE data_types_netcdf_module
     INTEGER :: id_dim_month
     INTEGER :: id_dim_lon
     INTEGER :: id_dim_lat
+    INTEGER :: id_dim_x
+    INTEGER :: id_dim_y
 
     CHARACTER(LEN=256) :: name_dim_time                  = 'time                 '
     CHARACTER(LEN=256) :: name_dim_month                 = 'month                '
     CHARACTER(LEN=256) :: name_dim_lon                   = 'lon                  '
     CHARACTER(LEN=256) :: name_dim_lat                   = 'lat                  '
+    CHARACTER(LEN=256) :: name_dim_x                     = 'NX                   '
+    CHARACTER(LEN=256) :: name_dim_y                     = 'NY                   '
 
     ! Variables
     INTEGER :: id_var_time
     INTEGER :: id_var_month
     INTEGER :: id_var_lon
     INTEGER :: id_var_lat
+    INTEGER :: id_var_x
+    INTEGER :: id_var_y
     INTEGER :: id_var_T2m
     INTEGER :: id_var_Precip
     INTEGER :: id_var_SMB
@@ -728,6 +734,8 @@ MODULE data_types_netcdf_module
     CHARACTER(LEN=256) :: name_var_month                 = 'month                '
     CHARACTER(LEN=256) :: name_var_lon                   = 'lon                  '
     CHARACTER(LEN=256) :: name_var_lat                   = 'lat                  '
+    CHARACTER(LEN=256) :: name_var_x                     = 'x                    '
+    CHARACTER(LEN=256) :: name_var_y                     = 'y                    '
     CHARACTER(LEN=256) :: name_var_T2m                   = 'T2m                  '
     CHARACTER(LEN=256) :: name_var_Precip                = 'Precip               '
     CHARACTER(LEN=256) :: name_var_SMB                   = 'SMB                  '

--- a/src_dev/netcdf_module.f90
+++ b/src_dev/netcdf_module.f90
@@ -2807,30 +2807,63 @@ CONTAINS
     
     ! Inquire dimensions id's. Check that all required dimensions exist return their lengths.
     CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_time,     forcing%clim_nyears,        forcing%netcdf_clim%id_dim_time)
-    CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_lat,      forcing%clim_nlat,          forcing%netcdf_clim%id_dim_lat)
-    CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_lon,      forcing%clim_nlon,          forcing%netcdf_clim%id_dim_lon)
     IF (C%choice_forcing_method == 'climate_direct') THEN
       CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_month,    int_dummy,                  forcing%netcdf_clim%id_dim_month)  
     END IF
+    IF (C%domain_climate_forcing == 'global') THEN
+      CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_lat,      forcing%clim_nlat,          forcing%netcdf_clim%id_dim_lat)
+      CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_lon,      forcing%clim_nlon,          forcing%netcdf_clim%id_dim_lon)
+    ELSEIF (C%domain_climate_forcing == 'regional') THEN
+      CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_y,        forcing%clim_ny,            forcing%netcdf_clim%id_dim_y)
+      CALL inquire_dim( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_dim_x,        forcing%clim_nx,            forcing%netcdf_clim%id_dim_x)
+    ELSE
+      IF (par%master) WRITE(0,*) '  ERROR: domain_climate_forcing "', TRIM(C%choice_benchmark_experiment), '" not implemented in inquire_climate_forcing_data_file!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+    END IF    
 
     ! Inquire variable id's. Make sure that each variable has the correct dimensions:
-    CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_time,  (/ forcing%netcdf_clim%id_dim_time                                                                 /), forcing%netcdf_clim%id_var_time)
-    CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_lat,   (/ forcing%netcdf_clim%id_dim_lat                                                                  /), forcing%netcdf_clim%id_var_lat)
-    CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_lon,   (/ forcing%netcdf_clim%id_dim_lon                                                                  /), forcing%netcdf_clim%id_var_lon)
-    IF (C%choice_forcing_method == 'climate_direct') THEN
-      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_month, (/ forcing%netcdf_clim%id_dim_month                                                                /), forcing%netcdf_clim%id_var_month)
-    END IF
+    IF (C%domain_climate_forcing == 'global') THEN
+      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_time,  (/ forcing%netcdf_clim%id_dim_time                                                                 /), forcing%netcdf_clim%id_var_time)
+      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_lat,   (/ forcing%netcdf_clim%id_dim_lat                                                                  /), forcing%netcdf_clim%id_var_lat)
+      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_lon,   (/ forcing%netcdf_clim%id_dim_lon                                                                  /), forcing%netcdf_clim%id_var_lon)
+      IF (C%choice_forcing_method == 'climate_direct') THEN
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_month, (/ forcing%netcdf_clim%id_dim_month                                                                /), forcing%netcdf_clim%id_var_month)
+      END IF
 
-    IF (C%choice_forcing_method == 'SMB_direct') THEN
-      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_SMB,    (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_SMB   )
-      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_T2m,    (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_T2m   )
-    ELSE IF (C%choice_forcing_method == 'climate_direct') THEN
-      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_T2m,    (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_month,  forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_T2m   )
-      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_Precip, (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_month,  forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_Precip)
+      IF (C%choice_forcing_method == 'SMB_direct') THEN
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_SMB,    (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_SMB   )
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_T2m,    (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_T2m   )
+      ELSE IF (C%choice_forcing_method == 'climate_direct') THEN
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_T2m,    (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_month,  forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_T2m   )
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_Precip, (/ forcing%netcdf_clim%id_dim_lon, forcing%netcdf_clim%id_dim_lat, forcing%netcdf_clim%id_dim_month,  forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_Precip)
+      ELSE
+        IF (par%master) WRITE(0,*) '  ERROR: choice_forcing_method "', TRIM(C%choice_forcing_method), '" not implemented in inquire_climate_forcing_data_file!'
+        CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+      END IF
+
+    ELSE IF (C%domain_climate_forcing == 'regional') THEN
+      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_time,  (/ forcing%netcdf_clim%id_dim_time                                                                 /), forcing%netcdf_clim%id_var_time)
+      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_y,   (/ forcing%netcdf_clim%id_dim_y                                                                      /), forcing%netcdf_clim%id_var_y)
+      CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_x,   (/ forcing%netcdf_clim%id_dim_x                                                                      /), forcing%netcdf_clim%id_var_x)
+      IF (C%choice_forcing_method == 'climate_direct') THEN
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_month, (/ forcing%netcdf_clim%id_dim_month                                                                /), forcing%netcdf_clim%id_var_month)
+      END IF
+
+      IF (C%choice_forcing_method == 'SMB_direct') THEN
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_SMB,    (/ forcing%netcdf_clim%id_dim_x, forcing%netcdf_clim%id_dim_y, forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_SMB   )
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_T2m,    (/ forcing%netcdf_clim%id_dim_x, forcing%netcdf_clim%id_dim_y, forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_T2m   )
+      ELSE IF (C%choice_forcing_method == 'climate_direct') THEN
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_T2m,    (/ forcing%netcdf_clim%id_dim_x, forcing%netcdf_clim%id_dim_y, forcing%netcdf_clim%id_dim_month,  forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_T2m   )
+        CALL inquire_double_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%name_var_Precip, (/ forcing%netcdf_clim%id_dim_x, forcing%netcdf_clim%id_dim_y, forcing%netcdf_clim%id_dim_month,  forcing%netcdf_clim%id_dim_time /), forcing%netcdf_clim%id_var_Precip)
+      ELSE
+        IF (par%master) WRITE(0,*) '  ERROR: choice_forcing_method "', TRIM(C%choice_forcing_method), '" not implemented in inquire_climate_forcing_data_file!'
+        CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+      END IF
+
     ELSE
-      IF (par%master) WRITE(0,*) '  ERROR: choice_forcing_method "', TRIM(C%choice_forcing_method), '" not implemented in inquire_climate_forcing_data_file!'
+      IF (par%master) WRITE(0,*) '  ERROR: domain_climate_forcing "', TRIM(C%choice_benchmark_experiment), '" not implemented in inquire_climate_forcing_data_file!'
       CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
-    END IF
+    END IF 
         
     ! Close the netcdf file
     CALL close_netcdf_file(forcing%netcdf_clim%ncid)
@@ -2852,31 +2885,64 @@ CONTAINS
     
     IF (.NOT. par%master) RETURN
 
-    ! Temporary memory to store the data read from the netCDF file
-    ALLOCATE(  SMB_temp0(forcing%clim_nlon,forcing%clim_nlat, 1))
-    ALLOCATE(  SMB_temp1(forcing%clim_nlon,forcing%clim_nlat, 1))
-    ALLOCATE( T2my_temp0(forcing%clim_nlon,forcing%clim_nlat, 1))
-    ALLOCATE( T2my_temp1(forcing%clim_nlon,forcing%clim_nlat, 1))
+    IF (C%domain_climate_forcing == 'global') THEN
+      ! Temporary memory to store the data read from the netCDF file
+      ALLOCATE(  SMB_temp0(forcing%clim_nlon,forcing%clim_nlat, 1))
+      ALLOCATE(  SMB_temp1(forcing%clim_nlon,forcing%clim_nlat, 1))
+      ALLOCATE( T2my_temp0(forcing%clim_nlon,forcing%clim_nlat, 1))
+      ALLOCATE( T2my_temp1(forcing%clim_nlon,forcing%clim_nlat, 1))
         
-    ! Read data
-    CALL open_netcdf_file(forcing%netcdf_clim%filename, forcing%netcdf_clim%ncid)
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_SMB,  SMB_temp0, start = (/ 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_SMB,  SMB_temp1, start = (/ 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m, T2my_temp0, start = (/ 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m, T2my_temp1, start = (/ 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
-    CALL close_netcdf_file(forcing%netcdf_clim%ncid)
+      ! Read data
+      CALL open_netcdf_file(forcing%netcdf_clim%filename, forcing%netcdf_clim%ncid)
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_SMB,  SMB_temp0, start = (/ 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_SMB,  SMB_temp1, start = (/ 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m, T2my_temp0, start = (/ 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m, T2my_temp1, start = (/ 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL close_netcdf_file(forcing%netcdf_clim%ncid)
 
-    ! Store the data in the shared memory structure
-    DO li = 1, forcing%clim_nlon
-    DO ki = 1, forcing%clim_nlat   
-      clim_SMB0 ( li,ki)      =     SMB_temp0( li,ki,1)
-      clim_SMB1 ( li,ki)      =     SMB_temp1( li,ki,1)
-      DO mi = 1, 12
-        clim_T2m0 ( li,ki,mi) =    T2my_temp0( li,ki,1)
-        clim_T2m1 ( li,ki,mi) =    T2my_temp1( li,ki,1)
+      ! Store the data in the shared memory structure
+      DO li = 1, forcing%clim_nlon
+      DO ki = 1, forcing%clim_nlat   
+        clim_SMB0 ( li,ki)      =     SMB_temp0( li,ki,1)
+        clim_SMB1 ( li,ki)      =     SMB_temp1( li,ki,1)
+        DO mi = 1, 12
+          clim_T2m0 ( li,ki,mi) =    T2my_temp0( li,ki,1)
+          clim_T2m1 ( li,ki,mi) =    T2my_temp1( li,ki,1)
+        END DO
       END DO
-    END DO
-    END DO
+      END DO
+
+    ELSEIF (C%domain_climate_forcing == 'regional') THEN
+      ! Temporary memory to store the data read from the netCDF file
+      ALLOCATE(  SMB_temp0(forcing%clim_nx,forcing%clim_ny, 1))
+      ALLOCATE(  SMB_temp1(forcing%clim_nx,forcing%clim_ny, 1))
+      ALLOCATE( T2my_temp0(forcing%clim_nx,forcing%clim_ny, 1))
+      ALLOCATE( T2my_temp1(forcing%clim_nx,forcing%clim_ny, 1))
+        
+      ! Read data
+      CALL open_netcdf_file(forcing%netcdf_clim%filename, forcing%netcdf_clim%ncid)
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_SMB,  SMB_temp0, start = (/ 1, 1, ti0 /), count = (/ forcing%clim_nx, forcing%clim_ny, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_SMB,  SMB_temp1, start = (/ 1, 1, ti1 /), count = (/ forcing%clim_nx, forcing%clim_ny, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m, T2my_temp0, start = (/ 1, 1, ti0 /), count = (/ forcing%clim_nx, forcing%clim_ny, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m, T2my_temp1, start = (/ 1, 1, ti1 /), count = (/ forcing%clim_nx, forcing%clim_ny, 1 /), stride = (/ 1, 1, 1 /) ))
+      CALL close_netcdf_file(forcing%netcdf_clim%ncid)
+
+      ! Store the data in the shared memory structure
+      DO li = 1, forcing%clim_nx
+      DO ki = 1, forcing%clim_ny   
+        clim_SMB0 ( ki,li)      =     SMB_temp0( li,ki,1)
+        clim_SMB1 ( ki,li)      =     SMB_temp1( li,ki,1)
+        DO mi = 1, 12
+          clim_T2m0 ( mi,ki,li) =    T2my_temp0( li,ki,1)
+          clim_T2m1 ( mi,ki,li) =    T2my_temp1( li,ki,1)
+        END DO
+      END DO
+      END DO
+
+    ELSE
+      IF (par%master) WRITE(0,*) '  ERROR: domain_climate_forcing "', TRIM(C%choice_benchmark_experiment), '" not implemented in read_climate_forcing_data_file_SMB!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+    END IF
 
     DEALLOCATE( SMB_temp0)
     DEALLOCATE( SMB_temp1)
@@ -2899,31 +2965,65 @@ CONTAINS
     
     IF (.NOT. par%master) RETURN
 
-    ! Temporary memory to store the data read from the netCDF file
-    ALLOCATE(    T2m_temp0(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
-    ALLOCATE(    T2m_temp1(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
-    ALLOCATE( Precip_temp0(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
-    ALLOCATE( Precip_temp1(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
-        
-    ! Read data
-    CALL open_netcdf_file(forcing%netcdf_clim%filename, forcing%netcdf_clim%ncid)
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m,    T2m_temp0,    start = (/ 1, 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m,    T2m_temp1,    start = (/ 1, 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_Precip, Precip_temp0, start = (/ 1, 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
-    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_Precip, Precip_temp1, start = (/ 1, 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
-    CALL close_netcdf_file(forcing%netcdf_clim%ncid)
 
-    ! Store the data in the shared memory structure
-    DO mi = 1, 12
-    DO li = 1, forcing%clim_nlon
-    DO ki = 1, forcing%clim_nlat 
-      clim_T2m0(    li,ki,mi) =    T2m_temp0( li,ki,mi,1)
-      clim_T2m1(    li,ki,mi) =    T2m_temp1( li,ki,mi,1)
-      clim_Precip0( li,ki,mi) = Precip_temp0( li,ki,mi,1)
-      clim_Precip1( li,ki,mi) = Precip_temp1( li,ki,mi,1)
-    END DO
-    END DO
-    END DO
+    IF (C%domain_climate_forcing == 'global') THEN
+      ! Temporary memory to store the data read from the netCDF file
+      ALLOCATE(    T2m_temp0(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
+      ALLOCATE(    T2m_temp1(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
+      ALLOCATE( Precip_temp0(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
+      ALLOCATE( Precip_temp1(forcing%clim_nlon,forcing%clim_nlat, 12, 1))
+        
+      ! Read data
+      CALL open_netcdf_file(forcing%netcdf_clim%filename, forcing%netcdf_clim%ncid)
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m,    T2m_temp0,    start = (/ 1, 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m,    T2m_temp1,    start = (/ 1, 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_Precip, Precip_temp0, start = (/ 1, 1, 1, ti0 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_Precip, Precip_temp1, start = (/ 1, 1, 1, ti1 /), count = (/ forcing%clim_nlon, forcing%clim_nlat, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL close_netcdf_file(forcing%netcdf_clim%ncid)
+
+      ! Store the data in the shared memory structure
+      DO mi = 1, 12
+      DO li = 1, forcing%clim_nlon
+      DO ki = 1, forcing%clim_nlat 
+        clim_T2m0(    li,ki,mi) =    T2m_temp0( li,ki,mi,1)
+        clim_T2m1(    li,ki,mi) =    T2m_temp1( li,ki,mi,1)
+        clim_Precip0( li,ki,mi) = Precip_temp0( li,ki,mi,1)
+        clim_Precip1( li,ki,mi) = Precip_temp1( li,ki,mi,1)
+      END DO
+      END DO
+      END DO
+
+    ELSEIF (C%domain_climate_forcing == 'regional') THEN
+      ! Temporary memory to store the data read from the netCDF file
+      ALLOCATE(    T2m_temp0(forcing%clim_nx,forcing%clim_ny, 12, 1))
+      ALLOCATE(    T2m_temp1(forcing%clim_nx,forcing%clim_ny, 12, 1))
+      ALLOCATE( Precip_temp0(forcing%clim_nx,forcing%clim_ny, 12, 1))
+      ALLOCATE( Precip_temp1(forcing%clim_nx,forcing%clim_ny, 12, 1))
+        
+      ! Read data
+      CALL open_netcdf_file(forcing%netcdf_clim%filename, forcing%netcdf_clim%ncid)
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m,    T2m_temp0,    start = (/ 1, 1, 1, ti0 /), count = (/ forcing%clim_nx, forcing%clim_ny, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_T2m,    T2m_temp1,    start = (/ 1, 1, 1, ti1 /), count = (/ forcing%clim_nx, forcing%clim_ny, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_Precip, Precip_temp0, start = (/ 1, 1, 1, ti0 /), count = (/ forcing%clim_nx, forcing%clim_ny, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_Precip, Precip_temp1, start = (/ 1, 1, 1, ti1 /), count = (/ forcing%clim_nx, forcing%clim_ny, 12, 1 /), stride = (/ 1, 1, 1, 1 /) ))
+      CALL close_netcdf_file(forcing%netcdf_clim%ncid)
+
+      ! Store the data in the shared memory structure
+      DO mi = 1, 12
+      DO li = 1, forcing%clim_nx
+      DO ki = 1, forcing%clim_ny 
+        clim_T2m0(    li,ki,mi) =    T2m_temp0( li,ki,mi,1)
+        clim_T2m1(    li,ki,mi) =    T2m_temp1( li,ki,mi,1)
+        clim_Precip0( li,ki,mi) = Precip_temp0( li,ki,mi,1)
+        clim_Precip1( li,ki,mi) = Precip_temp1( li,ki,mi,1)
+      END DO
+      END DO
+      END DO
+
+    ELSE
+      IF (par%master) WRITE(0,*) '  ERROR: domain_climate_forcing "', TRIM(C%choice_benchmark_experiment), '" not implemented in read_climate_forcing_data_file_SMB!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+    END IF
 
     DEALLOCATE(    T2m_temp0)
     DEALLOCATE(    T2m_temp1)
@@ -2952,6 +3052,27 @@ CONTAINS
     CALL close_netcdf_file(forcing%netcdf_ins%ncid)
     
   END SUBROUTINE read_climate_forcing_data_file_time_latlon
+
+  SUBROUTINE read_climate_forcing_data_file_time_xy( forcing) 
+    IMPLICIT NONE
+    
+    ! Output variable
+    TYPE(type_forcing_data), INTENT(INOUT) :: forcing
+    
+    IF (.NOT. par%master) RETURN
+    
+    ! Open the netcdf file
+    CALL open_netcdf_file(forcing%netcdf_clim%filename, forcing%netcdf_clim%ncid)
+    
+    ! Read the data
+    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_time,    forcing%clim_time,    start = (/ 1 /) ))
+    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_x,       forcing%clim_x,       start = (/ 1 /) ))
+    CALL handle_error(nf90_get_var( forcing%netcdf_clim%ncid, forcing%netcdf_clim%id_var_y,       forcing%clim_y,       start = (/ 1 /) ))
+        
+    ! Close the netcdf file
+    CALL close_netcdf_file(forcing%netcdf_ins%ncid)
+    
+  END SUBROUTINE read_climate_forcing_data_file_time_xy
   
   ! Global topography for SELEN
   SUBROUTINE inquire_SELEN_global_topo_file( SELEN)


### PR DESCRIPTION
Regional climate forcing, i.e. forcing that is pre-mapped to the ice
sheet model grid, can now be used when C%choice_forcing_method ==
'SMB_direct' or 'climate_direct', by setting the option
C%domain_climate_forcing == 'regional' (set to 'global' by default). The
climate forcing should cover the entire ice grid, but not necessarily on the
same resolution. This enables us to e.g. use RACMO climate forcing input.