### PR TITLE
Enabling the use of a matrix method to calculate ocean forcing

### DIFF
--- a/src/IMAU_ICE_main_model.f90
+++ b/src/IMAU_ICE_main_model.f90
@@ -28,7 +28,7 @@ MODULE IMAU_ICE_main_model
   USE ice_dynamics_module,             ONLY: initialise_ice_model,       run_ice_model
   USE calving_module,                  ONLY: apply_calving_law
   USE thermodynamics_module,           ONLY: initialise_ice_temperature, run_thermo_model
-  USE ocean_module,                    ONLY: initialise_oceans_regional
+  USE ocean_module,                    ONLY: initialise_oceans_regional, run_ocean_model
   USE climate_module,                  ONLY: initialise_climate_model,   run_climate_model
   USE SMB_module,                      ONLY: initialise_SMB_model,       run_SMB_model
   USE BMB_module,                      ONLY: initialise_BMB_model,       run_BMB_model
@@ -114,6 +114,11 @@ CONTAINS
       IF (region%do_climate) THEN
         CALL run_climate_model( region%grid, region%ice, region%SMB, region%climate, region%name, region%time)
       END IF
+      
+      ! Run the ocean model
+      IF (region%do_ocean) THEN
+        CALL run_ocean_model( region%grid, region%ice, region%climate, region%name, region%time)
+      END IF     
     
       ! Run the SMB model
       IF (region%do_SMB) THEN
@@ -255,6 +260,10 @@ CONTAINS
     CALL allocate_shared_dp_0D(   region%t_next_climate,   region%wt_next_climate  )
     CALL allocate_shared_bool_0D( region%do_climate,       region%wdo_climate      )
     
+    CALL allocate_shared_dp_0D(   region%t_last_ocean,     region%wt_last_ocean    )
+    CALL allocate_shared_dp_0D(   region%t_next_ocean,     region%wt_next_ocean    )
+    CALL allocate_shared_bool_0D( region%do_ocean,         region%wdo_ocean        )
+    
     CALL allocate_shared_dp_0D(   region%t_last_SMB,       region%wt_last_SMB      )
     CALL allocate_shared_dp_0D(   region%t_next_SMB,       region%wt_next_SMB      )
     CALL allocate_shared_bool_0D( region%do_SMB,           region%wdo_SMB          )
@@ -291,6 +300,10 @@ CONTAINS
       region%t_last_climate = C%start_time_of_run
       region%t_next_climate = C%start_time_of_run
       region%do_climate     = .TRUE.
+      
+      region%t_last_ocean   = C%start_time_of_run
+      region%t_next_ocean   = C%start_time_of_run
+      region%do_ocean       = .TRUE.
       
       region%t_last_SMB     = C%start_time_of_run
       region%t_next_SMB     = C%start_time_of_run
@@ -390,7 +403,7 @@ CONTAINS
     
     CALL initialise_climate_model( region%grid, region%climate, matrix, region%name, region%mask_noice)
     
-    ! ===== The climate model =====
+    ! ===== The ocean model =====
     ! =============================
     
     CALL initialise_oceans_regional( region%grid, region%ice, region%climate, matrix)   

--- a/src/IMAU_ICE_program.f90
+++ b/src/IMAU_ICE_program.f90
@@ -28,6 +28,7 @@ PROGRAM IMAU_ICE_program
                                              calculate_modelled_d18O, initialise_inverse_routine_data, inverse_routine_global_temperature_offset, inverse_routine_CO2, &
                                              initialise_geothermal_heat_flux, initialise_climate_SMB_forcing_data, update_climate_SMB_forcing_data
   USE climate_module,                  ONLY: initialise_climate_matrix
+  USE ocean_module,                    ONLY: initialise_ocean_matrix
   USE derivatives_and_grids_module,    ONLY: initialise_zeta_discretisation
   USE IMAU_ICE_main_model,             ONLY: initialise_model, run_model
   USE SELEN_main_module,               ONLY: initialise_SELEN, run_SELEN
@@ -126,6 +127,11 @@ PROGRAM IMAU_ICE_program
   ELSE
     CALL initialise_climate_matrix( matrix)
   END IF
+  
+  ! ===== Initialise the ocean matrix =====
+  ! =======================================
+  
+  CALL initialise_ocean_matrix ( matrix)  
     
   ! ===== Initialise the model regions ======
   ! =========================================

--- a/src/climate_module.f90
+++ b/src/climate_module.f90
@@ -137,8 +137,8 @@ CONTAINS
 
       ! Map the interpolated timeframe to the model grid
       IF     (C%domain_climate_forcing == 'global') THEN
-        CALL map_glob_to_grid_3D(                    forcing%clim_nlat, forcing%clim_nlon, forcing%clim_lat, forcing%clim_lon, grid,                             forcing%clim_T2m2,    climate%applied%T2m,    12)
-        CALL map_glob_to_grid_3D(                    forcing%clim_nlat, forcing%clim_nlon, forcing%clim_lat, forcing%clim_lon, grid,                             forcing%clim_Precip2, climate%applied%Precip, 12) 
+        CALL map_glob_to_grid_3D(                    forcing%clim_nlat, forcing%clim_nlon, forcing%clim_lat, forcing%clim_lon, grid, forcing%clim_T2m2,    climate%applied%T2m,    12)
+        CALL map_glob_to_grid_3D(                    forcing%clim_nlat, forcing%clim_nlon, forcing%clim_lat, forcing%clim_lon, grid, forcing%clim_Precip2, climate%applied%Precip, 12) 
       ELSEIF (C%domain_climate_forcing == 'regional') THEN
         CALL map_square_to_square_cons_2nd_order_3D( forcing%clim_nx,   forcing%clim_ny,   forcing%clim_x,   forcing%clim_y,   grid%nx, grid%ny, grid%x, grid%y, forcing%clim_T2m2, climate%applied%T2m, 12)
         CALL map_square_to_square_cons_2nd_order_3D( forcing%clim_nx,   forcing%clim_ny,   forcing%clim_x,   forcing%clim_y,   grid%nx, grid%ny, grid%x, grid%y, forcing%clim_Precip2, climate%applied%Precip, 12)      
@@ -1101,6 +1101,13 @@ CONTAINS
         CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
       END IF
     END IF ! IF (C%do_benchmark_experiment) THEN
+
+    ! Exception: if we're using a prescribed climate/SMB forcing, the entire matrix is not used
+    IF (C%choice_forcing_method == 'climate_direct' .OR. C%choice_forcing_method == 'SMB_direct') THEN
+      CALL initialise_subclimate( grid, climate%PD_obs,   'ERA40'  )
+      CALL initialise_subclimate( grid, climate%applied,  'applied')
+      RETURN
+    END IF
         
     ! Initialise data structures for the regional ERA40 climate and the final applied climate
     CALL initialise_subclimate( grid, climate%PD_obs,   'ERA40'  )

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -38,6 +38,7 @@ MODULE configuration_module
   REAL(dp)            :: dt_max_config                           = 10.0_dp                          ! Maximum time step (in years) of the ice model
   REAL(dp)            :: dt_thermo_config                        = 10.0_dp                          ! Time step (in years) for updating thermodynamics
   REAL(dp)            :: dt_climate_config                       = 10._dp                           ! Time step (in years) for updating the climate
+  REAL(dp)            :: dt_ocean_config                         = 10._dp                           ! Time step (in years) for updating the ocean
   REAL(dp)            :: dt_SMB_config                           = 10._dp                           ! Time step (in years) for updating the SMB
   REAL(dp)            :: dt_BMB_config                           = 10._dp                           ! Time step (in years) for updating the BMB
   REAL(dp)            :: dt_bedrock_ELRA_config                  = 100._dp                          ! Time step (in years) for updating the bedrock deformation rate with the ELRA model
@@ -254,6 +255,11 @@ MODULE configuration_module
   CHARACTER(LEN=256)  :: filename_GCM_snapshot_PI_config         = 'Datasets/GCM_snapshots/Singarayer_Valdes_2010_PI_Control.nc'
   CHARACTER(LEN=256)  :: filename_GCM_snapshot_warm_config       = 'Datasets/GCM_snapshots/Singarayer_Valdes_2010_PI_Control.nc'
   CHARACTER(LEN=256)  :: filename_GCM_snapshot_cold_config       = 'Datasets/GCM_snapshots/Singarayer_Valdes_2010_LGM.nc'
+
+  CHARACTER(LEN=256)  :: filename_GCM_ocean_snapshot_PI_config   = 'Datasets/COSMOS_ocean_examples/COSMOS_PI_oceanTS_prep.nc'
+  CHARACTER(LEN=256)  :: filename_GCM_ocean_snapshot_warm_config = 'Datasets/COSMOS_ocean_examples/COSMOS_PI_oceanTS_prep.nc'
+  CHARACTER(LEN=256)  :: filename_GCM_ocean_snapshot_cold_config = 'Datasets/COSMOS_ocean_examples/COSMOS_LGM_oceanTS_prep.nc'  
+
   ! GCM forcing file
   CHARACTER(LEN=256)  :: filename_GCM_climate_config             = 'Datasets/GCM_snapshots/Singarayer_Valdes_2010_PI_Control.nc'
   
@@ -275,11 +281,16 @@ MODULE configuration_module
   REAL(dp)            :: climate_matrix_CO2vsice_GRL_config          = 0.75_dp                      ! Default values are from Berends et al, 2018
   REAL(dp)            :: climate_matrix_CO2vsice_ANT_config          = 0.75_dp                      ! 1.0_dp equals glacial index method
 
-  REAL(dp)            :: climate_matrix_high_CO2_level_config        = 280._dp                      ! CO2 level pertaining to the warm climate (PI  level default)         
-  REAL(dp)            :: climate_matrix_low_CO2_level_config         = 190._dp                      ! CO2 level pertaining to the cold climate (LGM level default)          
+  REAL(dp)            :: ocean_matrix_CO2vsice_NAM_config            = 1.0_dp                       ! Weight factor for the influence of CO2 vs ice cover on ocean T and S 
+  REAL(dp)            :: ocean_matrix_CO2vsice_EAS_config            = 1.0_dp                       ! Can be set separately for different regions
+  REAL(dp)            :: ocean_matrix_CO2vsice_GRL_config            = 1.0_dp                       
+  REAL(dp)            :: ocean_matrix_CO2vsice_ANT_config            = 1.0_dp                       
 
-  REAL(dp)            :: climate_matrix_warm_orbit_time_config       = 0._dp                        ! Orbit time pertaining to the warm climate (PI default)
-  REAL(dp)            :: climate_matrix_cold_orbit_time_config       = -21000._dp                   ! Orbit time pertaining to the cold climate (LGM default)
+  REAL(dp)            :: matrix_high_CO2_level_config                = 280._dp                      ! CO2 level pertaining to the warm climate (PI  level default)         
+  REAL(dp)            :: matrix_low_CO2_level_config                 = 190._dp                      ! CO2 level pertaining to the cold climate (LGM level default)          
+
+  REAL(dp)            :: matrix_warm_orbit_time_config               = 0._dp                        ! Orbit time pertaining to the warm climate (PI default)
+  REAL(dp)            :: matrix_cold_orbit_time_config               = -21000._dp                   ! Orbit time pertaining to the cold climate (LGM default)
   
   LOGICAL             :: climate_matrix_biascorrect_warm_config      = .TRUE.                       ! Whether or not to apply a bias correction (modelled vs observed PI climate) to the "warm" GCM snapshot
   LOGICAL             :: climate_matrix_biascorrect_cold_config      = .TRUE.                       ! Whether or not to apply a bias correction (modelled vs observed PI climate) to the "cold" GCM snapshot
@@ -534,6 +545,7 @@ MODULE configuration_module
     REAL(dp)                            :: dt_max
     REAL(dp)                            :: dt_thermo
     REAL(dp)                            :: dt_climate
+    REAL(dp)                            :: dt_ocean
     REAL(dp)                            :: dt_SMB
     REAL(dp)                            :: dt_BMB
     REAL(dp)                            :: dt_bedrock_ELRA
@@ -723,6 +735,9 @@ MODULE configuration_module
     CHARACTER(LEN=256)                  :: filename_GCM_snapshot_PI
     CHARACTER(LEN=256)                  :: filename_GCM_snapshot_warm
     CHARACTER(LEN=256)                  :: filename_GCM_snapshot_cold
+    CHARACTER(LEN=256)                  :: filename_GCM_ocean_snapshot_PI
+    CHARACTER(LEN=256)                  :: filename_GCM_ocean_snapshot_warm
+    CHARACTER(LEN=256)                  :: filename_GCM_ocean_snapshot_cold
     CHARACTER(LEN=256)                  :: filename_GCM_climate
     
     CHARACTER(LEN=256)                  :: choice_ocean_temperature_model
@@ -738,10 +753,15 @@ MODULE configuration_module
     REAL(dp)                            :: climate_matrix_CO2vsice_GRL
     REAL(dp)                            :: climate_matrix_CO2vsice_ANT
 
-    REAL(dp)                            :: climate_matrix_high_CO2_level
-    REAL(dp)                            :: climate_matrix_low_CO2_level
-    REAL(dp)                            :: climate_matrix_warm_orbit_time
-    REAL(dp)                            :: climate_matrix_cold_orbit_time
+    REAL(dp)                            :: ocean_matrix_CO2vsice_NAM
+    REAL(dp)                            :: ocean_matrix_CO2vsice_EAS
+    REAL(dp)                            :: ocean_matrix_CO2vsice_GRL
+    REAL(dp)                            :: ocean_matrix_CO2vsice_ANT
+
+    REAL(dp)                            :: matrix_high_CO2_level
+    REAL(dp)                            :: matrix_low_CO2_level
+    REAL(dp)                            :: matrix_warm_orbit_time
+    REAL(dp)                            :: matrix_cold_orbit_time
     
     LOGICAL                             :: climate_matrix_biascorrect_warm
     LOGICAL                             :: climate_matrix_biascorrect_cold
@@ -1226,6 +1246,7 @@ CONTAINS
                      dt_max_config,                              &
                      dt_thermo_config,                           &
                      dt_climate_config,                          &
+                     dt_ocean_config,                            &
                      dt_SMB_config,                              &
                      dt_BMB_config,                              &
                      dt_bedrock_ELRA_config,                     &
@@ -1350,6 +1371,9 @@ CONTAINS
                      filename_GCM_snapshot_PI_config,            &
                      filename_GCM_snapshot_warm_config,          &
                      filename_GCM_snapshot_cold_config,          &
+                     filename_GCM_ocean_snapshot_PI_config,      &
+                     filename_GCM_ocean_snapshot_warm_config,    &
+                     filename_GCM_ocean_snapshot_cold_config,    &
                      filename_GCM_climate_config,                &
                      choice_ocean_temperature_model_config,      &
                      choice_schematic_ocean_config,              &
@@ -1361,10 +1385,14 @@ CONTAINS
                      climate_matrix_CO2vsice_EAS_config,         &
                      climate_matrix_CO2vsice_GRL_config,         &
                      climate_matrix_CO2vsice_ANT_config,         &
-                     climate_matrix_high_CO2_level_config,       &
-                     climate_matrix_low_CO2_level_config,        &
-                     climate_matrix_warm_orbit_time_config,      &
-                     climate_matrix_cold_orbit_time_config,      &
+                     ocean_matrix_CO2vsice_NAM_config,           &
+                     ocean_matrix_CO2vsice_EAS_config,           &
+                     ocean_matrix_CO2vsice_GRL_config,           &
+                     ocean_matrix_CO2vsice_ANT_config,           &
+                     matrix_high_CO2_level_config,               &
+                     matrix_low_CO2_level_config,                &
+                     matrix_warm_orbit_time_config,              &
+                     matrix_cold_orbit_time_config,              &
                      climate_matrix_biascorrect_warm_config,     &
                      climate_matrix_biascorrect_cold_config,     &
                      switch_glacial_index_precip_config,         &
@@ -1577,6 +1605,7 @@ CONTAINS
     C%dt_max                              = dt_max_config
     C%dt_thermo                           = dt_thermo_config
     C%dt_climate                          = dt_climate_config
+    C%dt_ocean                            = dt_ocean_config
     C%dt_SMB                              = dt_SMB_config
     C%dt_BMB                              = dt_BMB_config
     C%dt_bedrock_ELRA                     = dt_bedrock_ELRA_config
@@ -1767,6 +1796,9 @@ CONTAINS
     C%filename_GCM_snapshot_PI            = filename_GCM_snapshot_PI_config
     C%filename_GCM_snapshot_warm          = filename_GCM_snapshot_warm_config
     C%filename_GCM_snapshot_cold          = filename_GCM_snapshot_cold_config
+    C%filename_GCM_ocean_snapshot_PI      = filename_GCM_ocean_snapshot_PI_config
+    C%filename_GCM_ocean_snapshot_warm    = filename_GCM_ocean_snapshot_warm_config
+    C%filename_GCM_ocean_snapshot_cold    = filename_GCM_ocean_snapshot_cold_config
     C%filename_GCM_climate                = filename_GCM_climate_config
     
     C%choice_ocean_temperature_model      = choice_ocean_temperature_model_config
@@ -1782,10 +1814,15 @@ CONTAINS
     C%climate_matrix_CO2vsice_GRL         = climate_matrix_CO2vsice_GRL_config
     C%climate_matrix_CO2vsice_ANT         = climate_matrix_CO2vsice_ANT_config
 
-    C%climate_matrix_high_CO2_level       = climate_matrix_high_CO2_level_config
-    C%climate_matrix_low_CO2_level        = climate_matrix_low_CO2_level_config
-    C%climate_matrix_warm_orbit_time      = climate_matrix_warm_orbit_time_config
-    C%climate_matrix_cold_orbit_time      = climate_matrix_cold_orbit_time_config
+    C%ocean_matrix_CO2vsice_NAM           = ocean_matrix_CO2vsice_NAM_config
+    C%ocean_matrix_CO2vsice_EAS           = ocean_matrix_CO2vsice_EAS_config
+    C%ocean_matrix_CO2vsice_GRL           = ocean_matrix_CO2vsice_GRL_config
+    C%ocean_matrix_CO2vsice_ANT           = ocean_matrix_CO2vsice_ANT_config
+
+    C%matrix_high_CO2_level               = matrix_high_CO2_level_config
+    C%matrix_low_CO2_level                = matrix_low_CO2_level_config
+    C%matrix_warm_orbit_time              = matrix_warm_orbit_time_config
+    C%matrix_cold_orbit_time              = matrix_cold_orbit_time_config
     
     C%climate_matrix_biascorrect_warm     = climate_matrix_biascorrect_warm_config
     C%climate_matrix_biascorrect_cold     = climate_matrix_biascorrect_cold_config

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -446,16 +446,13 @@ MODULE data_types_module
   TYPE type_climate_matrix
     ! The climate matrix data structure. Contains all the different global GCM snapshots.
     
-    ! The present-day observed climate (ERA40)
-    TYPE(type_subclimate_global)            :: PD_obs
+    ! The present-day observed climate (ERA40) & ocean (WOA18)
+    TYPE(type_subclimate_global)            :: PD_obs, PD_obs_ocean
     
-    ! The present-day observed ocean (WOA18)
-    TYPE(type_subclimate_global)            :: PD_obs_ocean
-    
-    ! The GCM snapshots.
-    TYPE(type_subclimate_global)            :: GCM_PI
-    TYPE(type_subclimate_global)            :: GCM_warm
-    TYPE(type_subclimate_global)            :: GCM_cold
+    ! The GCM snapshots for climate and ocean.
+    TYPE(type_subclimate_global)            :: GCM_PI, GCM_PI_ocean
+    TYPE(type_subclimate_global)            :: GCM_warm, GCM_warm_ocean
+    TYPE(type_subclimate_global)            :: GCM_cold, GCM_cold_ocean
   
   END TYPE type_climate_matrix
   
@@ -977,6 +974,7 @@ MODULE data_types_module
     REAL(dp), POINTER                       :: t_last_thermo,  t_next_thermo
     REAL(dp), POINTER                       :: t_last_output,  t_next_output
     REAL(dp), POINTER                       :: t_last_climate, t_next_climate
+    REAL(dp), POINTER                       :: t_last_ocean,   t_next_ocean
     REAL(dp), POINTER                       :: t_last_SMB,     t_next_SMB
     REAL(dp), POINTER                       :: t_last_BMB,     t_next_BMB
     REAL(dp), POINTER                       :: t_last_ELRA,    t_next_ELRA
@@ -985,14 +983,15 @@ MODULE data_types_module
     LOGICAL,  POINTER                       :: do_DIVA
     LOGICAL,  POINTER                       :: do_thermo
     LOGICAL,  POINTER                       :: do_climate
+    LOGICAL,  POINTER                       :: do_ocean
     LOGICAL,  POINTER                       :: do_SMB
     LOGICAL,  POINTER                       :: do_BMB
     LOGICAL,  POINTER                       :: do_output
     LOGICAL,  POINTER                       :: do_ELRA
     INTEGER :: wdt_crit_SIA, wdt_crit_SSA, wdt_crit_ice, wdt_crit_ice_prev
-    INTEGER :: wt_last_SIA, wt_last_SSA, wt_last_DIVA, wt_last_thermo, wt_last_output, wt_last_climate, wt_last_SMB, wt_last_BMB, wt_last_ELRA
-    INTEGER :: wt_next_SIA, wt_next_SSA, wt_next_DIVA, wt_next_thermo, wt_next_output, wt_next_climate, wt_next_SMB, wt_next_BMB, wt_next_ELRA
-    INTEGER ::     wdo_SIA,     wdo_SSA,     wdo_DIVA,     wdo_thermo,     wdo_output,     wdo_climate,     wdo_SMB,     wdo_BMB,     wdo_ELRA
+    INTEGER :: wt_last_SIA, wt_last_SSA, wt_last_DIVA, wt_last_thermo, wt_last_output, wt_last_climate, wt_last_ocean, wt_last_SMB, wt_last_BMB, wt_last_ELRA
+    INTEGER :: wt_next_SIA, wt_next_SSA, wt_next_DIVA, wt_next_thermo, wt_next_output, wt_next_climate, wt_next_ocean, wt_next_SMB, wt_next_BMB, wt_next_ELRA
+    INTEGER ::     wdo_SIA,     wdo_SSA,     wdo_DIVA,     wdo_thermo,     wdo_output,     wdo_climate,     wdo_ocean,     wdo_SMB,     wdo_BMB,     wdo_ELRA
     
     ! The region's ice sheet's volume and volume above flotation (in mSLE, so the second one is the ice sheets GMSL contribution)
     REAL(dp), POINTER                       :: ice_area

--- a/src/ice_dynamics_module.f90
+++ b/src/ice_dynamics_module.f90
@@ -520,6 +520,14 @@ CONTAINS
       END IF
       t_next = MIN( t_next, region%t_next_climate)
       
+      region%do_ocean   = .FALSE.
+      IF (region%time == region%t_next_ocean) THEN
+        region%do_ocean       = .TRUE.
+        region%t_last_ocean   = region%time
+        region%t_next_ocean   = region%t_last_ocean + C%dt_ocean
+      END IF
+      t_next = MIN( t_next, region%t_next_ocean)
+      
       region%do_SMB     = .FALSE.
       IF (region%time == region%t_next_SMB) THEN
         region%do_SMB         = .TRUE.

--- a/src/netcdf_module.f90
+++ b/src/netcdf_module.f90
@@ -2718,6 +2718,69 @@ CONTAINS
     
   END SUBROUTINE read_GCM_snapshot
   
+  ! GCM global ocean (ocean matrix snapshots)
+  SUBROUTINE inquire_GCM_ocean_snapshot( snapshot) 
+    ! Check if the right dimensions and variables are present in the file.
+   
+    IMPLICIT NONE
+    
+    ! Input variables:
+    TYPE(type_subclimate_global), INTENT(INOUT) :: snapshot
+ 
+    ! Local variables:
+    INTEGER                                     :: int_dummy
+    
+    IF (.NOT. par%master) RETURN
+        
+    ! Open the netcdf file
+    CALL open_netcdf_file( snapshot%netcdf%filename, snapshot%netcdf%ncid)
+ 
+     ! Inquire dimensions id's. Check that all required dimensions exist return their lengths.
+    CALL inquire_dim( snapshot%netcdf%ncid, snapshot%netcdf%name_dim_lat,     snapshot%nlat,     snapshot%netcdf%id_dim_lat    )
+    CALL inquire_dim( snapshot%netcdf%ncid, snapshot%netcdf%name_dim_lon,     snapshot%nlon,     snapshot%netcdf%id_dim_lon    )
+    CALL inquire_dim( snapshot%netcdf%ncid, snapshot%netcdf%name_dim_z_ocean, snapshot%nz_ocean, snapshot%netcdf%id_dim_z_ocean)
+
+    ! Inquire variable id's. Make sure that each variable has the correct dimensions:
+    CALL inquire_double_var( snapshot%netcdf%ncid, snapshot%netcdf%name_var_lat,     (/ snapshot%netcdf%id_dim_lat     /),  snapshot%netcdf%id_var_lat    )
+    CALL inquire_double_var( snapshot%netcdf%ncid, snapshot%netcdf%name_var_lon,     (/ snapshot%netcdf%id_dim_lon     /),  snapshot%netcdf%id_var_lon    )
+    CALL inquire_double_var( snapshot%netcdf%ncid, snapshot%netcdf%name_var_z_ocean, (/ snapshot%netcdf%id_dim_z_ocean /),  snapshot%netcdf%id_var_z_ocean)
+
+    !CALL inquire_double_var( snapshot%netcdf%ncid, snapshot%netcdf%name_var_mask_ocean, (/ snapshot%netcdf%id_dim_lon, snapshot%netcdf%id_dim_lat, snapshot%netcdf%id_dim_z_ocean /),  snapshot%netcdf%id_var_mask_ocean)
+    CALL inquire_double_var( snapshot%netcdf%ncid, snapshot%netcdf%name_var_T_ocean,    (/ snapshot%netcdf%id_dim_lon, snapshot%netcdf%id_dim_lat, snapshot%netcdf%id_dim_z_ocean /),  snapshot%netcdf%id_var_T_ocean)
+    CALL inquire_double_var( snapshot%netcdf%ncid, snapshot%netcdf%name_var_S_ocean,    (/ snapshot%netcdf%id_dim_lon, snapshot%netcdf%id_dim_lat, snapshot%netcdf%id_dim_z_ocean /),  snapshot%netcdf%id_var_S_ocean)
+   
+        
+    ! Close the netcdf file
+    CALL close_netcdf_file(snapshot%netcdf%ncid)
+    
+  END SUBROUTINE inquire_GCM_ocean_snapshot
+  SUBROUTINE read_GCM_ocean_snapshot(    snapshot)
+    ! Read the PD_obs0 netcdf file
+   
+    IMPLICIT NONE
+    
+    ! Input variables:
+    TYPE(type_subclimate_global), INTENT(INOUT) :: snapshot
+    
+    IF (.NOT. par%master) RETURN
+    
+    ! Open the netcdf file
+    CALL open_netcdf_file(snapshot%netcdf%filename, snapshot%netcdf%ncid)
+    
+    ! Read the data
+    CALL handle_error(nf90_get_var( snapshot%netcdf%ncid, snapshot%netcdf%id_var_lon,     snapshot%lon,     start = (/ 1       /) ))
+    CALL handle_error(nf90_get_var( snapshot%netcdf%ncid, snapshot%netcdf%id_var_lat,     snapshot%lat,     start = (/ 1       /) ))
+    CALL handle_error(nf90_get_var( snapshot%netcdf%ncid, snapshot%netcdf%id_var_z_ocean, snapshot%z_ocean, start = (/ 1       /) ))
+
+    !CALL handle_error(nf90_get_var( snapshot%netcdf%ncid, snapshot%netcdf%id_var_mask_ocean,  snapshot%mask_ocean,  start = (/ 1, 1, 1 /) ))
+    CALL handle_error(nf90_get_var( snapshot%netcdf%ncid, snapshot%netcdf%id_var_T_ocean,     snapshot%T_ocean, start = (/ 1, 1, 1 /) ))
+    CALL handle_error(nf90_get_var( snapshot%netcdf%ncid, snapshot%netcdf%id_var_S_ocean,     snapshot%S_ocean, start = (/ 1, 1, 1 /) ))
+        
+    ! Close the netcdf file
+    CALL close_netcdf_file(snapshot%netcdf%ncid)
+    
+  END SUBROUTINE read_GCM_ocean_snapshot  
+  
   ! Insolation solution (e.g. Laskar 2004)
   SUBROUTINE inquire_insolation_data_file( forcing)
     IMPLICIT NONE

--- a/src/ocean_module.f90
+++ b/src/ocean_module.f90
@@ -13,7 +13,9 @@ MODULE ocean_module
   USE data_types_module,               ONLY: type_grid, type_ice_model, type_climate_matrix, type_subclimate_global, &
                                              type_climate_model, type_subclimate_region
   USE netcdf_module,                   ONLY: debug, write_to_debug_file, &
-                                             inquire_PD_obs_data_file_ocean, read_PD_obs_data_file_ocean
+                                             inquire_PD_obs_data_file_ocean, read_PD_obs_data_file_ocean, &
+                                             inquire_GCM_ocean_snapshot, read_GCM_ocean_snapshot
+  USE forcing_module,                  ONLY: forcing
   USE utilities_module,                ONLY: check_for_NaN_dp_1D,  check_for_NaN_dp_2D,  check_for_NaN_dp_3D, &
                                              check_for_NaN_int_1D, check_for_NaN_int_2D, check_for_NaN_int_3D, &
                                              error_function, smooth_Gaussian_2D, smooth_Gaussian_3D, smooth_Shepard_2D, &
@@ -24,6 +26,297 @@ MODULE ocean_module
   IMPLICIT NONE
     
 CONTAINS
+
+  ! Run the climate model on a region grid
+  SUBROUTINE run_ocean_model( grid, ice, climate, region_name, time)
+    ! Run the regional climate model
+    
+    IMPLICIT NONE
+    
+    ! In/output variables:
+    TYPE(type_grid),                     INTENT(IN)    :: grid
+    TYPE(type_ice_model),                INTENT(IN)    :: ice
+    TYPE(type_climate_model),            INTENT(INOUT) :: climate
+    REAL(dp),                            INTENT(IN)    :: time
+    CHARACTER(LEN=3),                    INTENT(IN)    :: region_name
+
+  ! ================================================
+  ! ===== Exceptions for benchmark experiments =====
+  ! ================================================
+  
+    IF (C%do_benchmark_experiment) THEN
+      IF     (C%choice_benchmark_experiment == 'EISMINT_1' .OR. &
+              C%choice_benchmark_experiment == 'EISMINT_2' .OR. &
+              C%choice_benchmark_experiment == 'EISMINT_3' .OR. &
+              C%choice_benchmark_experiment == 'EISMINT_4' .OR. &
+              C%choice_benchmark_experiment == 'EISMINT_5' .OR. &
+              C%choice_benchmark_experiment == 'EISMINT_6' .OR. &
+              C%choice_benchmark_experiment == 'Halfar' .OR. &
+              C%choice_benchmark_experiment == 'Bueler' .OR. &
+              C%choice_benchmark_experiment == 'SSA_icestream' .OR. &
+              C%choice_benchmark_experiment == 'MISMIP_mod' .OR. &
+              C%choice_benchmark_experiment == 'ISMIP_HOM_A' .OR. &
+              C%choice_benchmark_experiment == 'ISMIP_HOM_B' .OR. &
+              C%choice_benchmark_experiment == 'ISMIP_HOM_C' .OR. &
+              C%choice_benchmark_experiment == 'ISMIP_HOM_D' .OR. &
+              C%choice_benchmark_experiment == 'ISMIP_HOM_E' .OR. &
+              C%choice_benchmark_experiment == 'ISMIP_HOM_F' .OR. &
+              C%choice_benchmark_experiment == 'MISMIPplus') THEN
+        RETURN
+      ELSEIF (C%choice_benchmark_experiment == 'MISOMIP1') THEN
+        ! Set ocean temperature/salinity profiles according to the MISOMIP+ protocol
+        CALL MISOMIP1_ocean_profiles( grid, climate%applied, time)
+        RETURN
+      ELSE
+        IF (par%master) WRITE(0,*) '  ERROR: benchmark experiment "', TRIM(C%choice_benchmark_experiment), '" not implemented in run_ocean_model!'
+        CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+      END IF
+    END IF ! IF (C%do_benchmark_experiment) THEN
+    
+  ! =======================================================
+  ! ===== End of exceptions for benchmark experiments =====
+  ! =======================================================
+    
+    
+    IF (C%choice_ocean_temperature_model == 'PI' .OR. &
+        C%choice_ocean_temperature_model == 'scaled' .OR. &
+        C%choice_ocean_temperature_model == 'schematic' .OR. &
+        C%choice_ocean_temperature_model == 'WOA') THEN
+      ! No need to update ocean temperature and salinity in these cases
+      RETURN        
+    ELSE IF (C%choice_ocean_temperature_model == 'matrix_warm_cold') THEN
+      CALL run_ocean_model_matrix_warm_cold (grid, ice, climate, region_name)
+    ELSE
+      IF (par%master) WRITE(0,*) '  ERROR: ocean model"', TRIM(C%choice_ocean_temperature_model), '" not implemented in run_ocean_model!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr) 
+    END IF
+      
+  END SUBROUTINE run_ocean_model
+  
+  ! Ocean matrix with warm and cold snapshots
+  SUBROUTINE run_ocean_model_matrix_warm_cold ( grid, ice, climate, region_name )
+  
+    IMPLICIT NONE
+
+    ! In/output variables:
+    TYPE(type_grid),                     INTENT(IN)    :: grid
+    TYPE(type_ice_model),                INTENT(IN)    :: ice
+    TYPE(type_climate_model),            INTENT(INOUT) :: climate
+    CHARACTER(LEN=3),                    INTENT(IN)    :: region_name
+    
+    ! Local variables:
+    INTEGER                                            :: i,j,k
+    REAL(dp)                                           :: CO2
+    REAL(dp)                                           :: w_CO2, w_ice, w_tot
+    REAL(dp)                                           :: w_cold, w_warm
+    REAL(dp), PARAMETER                                :: w_cutoff = 0.25_dp        ! Crop weights to [-w_cutoff, 1 + w_cutoff]
+
+      
+    ! Find CO2 interpolation weight (use either prescribed or modelled CO2)
+    ! =====================================================================
+    
+    IF (C%choice_forcing_method == 'CO2_direct') THEN
+      CO2 = forcing%CO2_obs
+    ELSEIF (C%choice_forcing_method == 'd18O_inverse_CO2') THEN
+      CO2 = forcing%CO2_mod
+    ELSEIF (C%choice_forcing_method == 'd18O_inverse_dT_glob') THEN
+      CO2 = 0._dp
+      WRITE(0,*) '  ERROR - run_cocean_model_matrix_warm_cold must only be called with the correct forcing method, check your code!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+    ELSE
+      CO2 = 0._dp
+      WRITE(0,*) '  ERROR - choice_forcing_method "', C%choice_forcing_method, '" not implemented in run_ocean_model_matrix_warm_cold!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+    END IF
+    
+    w_CO2 = MAX( -w_cutoff, MIN( 1._dp + w_cutoff, (CO2 - C%matrix_low_CO2_level) / (C%matrix_high_CO2_level - C%matrix_low_CO2_level) ))
+    
+    ! Find ice interpolation weight 
+    ! =============================
+    
+    ! First calculate the total ice volume term (second term in the equation)
+    w_ice = 1._dp - MAX(-w_cutoff, MIN(1._dp + w_cutoff, (SUM(ice%Hs_a) - SUM(climate%GCM_warm%Hs)) / (SUM(climate%GCM_cold%Hs) - SUM(climate%GCM_warm%Hs)) ))
+    
+    ! Combine weigths CO2 and ice
+    ! ===========================
+    
+    IF         (region_name == 'NAM') THEN
+      w_tot  = (C%ocean_matrix_CO2vsice_NAM * w_CO2) + ((1._dp - C%ocean_matrix_CO2vsice_NAM) * w_ice) 
+    ELSEIF     (region_name == 'EAS') THEN
+      w_tot  = (C%ocean_matrix_CO2vsice_EAS * w_CO2) + ((1._dp - C%ocean_matrix_CO2vsice_EAS) * w_ice) 
+    ELSEIF     (region_name == 'GRL') THEN
+      w_tot  = (C%ocean_matrix_CO2vsice_GRL * w_CO2) + ((1._dp - C%ocean_matrix_CO2vsice_GRL) * w_ice) 
+    ELSEIF     (region_name == 'ANT') THEN
+      w_tot  = (C%ocean_matrix_CO2vsice_ANT * w_CO2) + ((1._dp - C%ocean_matrix_CO2vsice_ANT) * w_ice) 
+    END IF
+    w_warm = w_tot
+    w_cold = 1._dp - w_warm
+    
+    ! Interpolate the GCM ocean snapshots
+    ! =============================
+    
+    DO i = grid%i1, grid%i2
+    DO j = 1, grid%ny
+      climate%applied%T_ocean_corr_ext(:,j,i) = (w_tot * climate%GCM_warm%T_ocean_corr_ext( :,j,i)) + ((1._dp - w_tot) * climate%GCM_cold%T_ocean_corr_ext( :,j,i))
+      climate%applied%S_ocean_corr_ext(:,j,i) = (w_tot * climate%GCM_warm%S_ocean_corr_ext( :,j,i)) + ((1._dp - w_tot) * climate%GCM_cold%S_ocean_corr_ext( :,j,i))      
+    END DO
+    END DO
+    CALL sync       
+    
+    
+      
+  END SUBROUTINE run_ocean_model_matrix_warm_cold
+
+  ! Initialising the ocean matrix, containing all the global subclimates
+  ! (PD observations and GCM snapshots) on their own lat-lon grids
+  SUBROUTINE initialise_ocean_matrix( matrix)
+    ! Allocate shared memory for the global ocean matrix
+  
+    IMPLICIT NONE
+    
+    ! In/output variables:
+    TYPE(type_climate_matrix),      INTENT(INOUT) :: matrix
+    
+    ! Exceptions for benchmark experiments
+    IF (C%do_benchmark_experiment) THEN
+      IF (C%choice_benchmark_experiment == 'Halfar'     .OR. &
+          C%choice_benchmark_experiment == 'Bueler'     .OR. &
+          C%choice_benchmark_experiment == 'EISMINT_1'  .OR. &
+          C%choice_benchmark_experiment == 'EISMINT_2'  .OR. &
+          C%choice_benchmark_experiment == 'EISMINT_3'  .OR. &
+          C%choice_benchmark_experiment == 'EISMINT_4'  .OR. &
+          C%choice_benchmark_experiment == 'EISMINT_5'  .OR. &
+          C%choice_benchmark_experiment == 'EISMINT_6'  .OR. &
+          C%choice_benchmark_experiment == 'MISMIP_mod' .OR. &
+          C%choice_benchmark_experiment == 'SSA_icestream' .OR. &
+          C%choice_benchmark_experiment == 'ISMIP_HOM_A' .OR. &
+          C%choice_benchmark_experiment == 'ISMIP_HOM_B' .OR. &
+          C%choice_benchmark_experiment == 'ISMIP_HOM_C' .OR. &
+          C%choice_benchmark_experiment == 'ISMIP_HOM_D' .OR. &
+          C%choice_benchmark_experiment == 'ISMIP_HOM_E' .OR. &
+          C%choice_benchmark_experiment == 'ISMIP_HOM_F' .OR. &
+          C%choice_benchmark_experiment == 'MISMIPplus' .OR. &
+          C%choice_benchmark_experiment == 'MISOMIP1') THEN
+        RETURN
+      ELSE 
+        IF (par%master) WRITE(0,*) '  ERROR: benchmark experiment "', TRIM(C%choice_benchmark_experiment), '" not implemented in initialise_ocean_matrix!'
+        CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+      END IF
+    END IF ! IF (C%do_benchmark_experiment) THEN
+    
+    IF (par%master) WRITE(0,*) ''
+    IF (par%master) WRITE(0,*) ' Initialising the ocean matrix...'
+    
+    ! The global WOA18 ocean
+    CALL initialise_PD_obs_ocean_fields ( matrix%PD_obs_ocean, 'WOA18')
+    
+    ! The different GCM snapshots 
+    IF ((C%choice_ocean_temperature_model == 'PI') .OR. (C%choice_ocean_temperature_model == 'scaled') .OR. &
+        (C%choice_ocean_temperature_model == 'schematic') .OR. (C%choice_ocean_temperature_model == 'WOA')) THEN
+      ! These choices of forcing don't use any GCM (snapshot) ocean data
+      RETURN
+    ELSEIF (C%choice_ocean_temperature_model == 'matrix_warm_cold') THEN
+      ! These two choices use the ocean matrix
+            
+      ! Initialise the GCM ocean snapshots
+      CALL initialise_ocean_snapshot( matrix%GCM_PI_ocean,   name = 'ref_PI_ocean', nc_filename = C%filename_GCM_ocean_snapshot_PI,   CO2 = 280._dp,                 orbit_time =       0._dp)
+      CALL initialise_ocean_snapshot( matrix%GCM_warm_ocean, name = 'warm_ocean',   nc_filename = C%filename_GCM_ocean_snapshot_warm, CO2 = C%matrix_high_CO2_level, orbit_time = C%matrix_warm_orbit_time)
+      CALL initialise_ocean_snapshot( matrix%GCM_cold_ocean, name = 'cold_ocean',   nc_filename = C%filename_GCM_ocean_snapshot_cold, CO2 = C%matrix_low_CO2_level,  orbit_time = C%matrix_cold_orbit_time)
+      
+    ELSE
+      IF (par%master) WRITE(0,*) '  ERROR: choice_ocean_temperature_model "', TRIM(C%choice_ocean_temperature_model), '" not implemented in initialise_ocean_matrix!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+    END IF
+    
+  END SUBROUTINE initialise_ocean_matrix
+  SUBROUTINE initialise_PD_obs_ocean_fields (PD_obs_ocean, name)
+     
+    IMPLICIT NONE
+      
+    ! Input variables:
+    TYPE(type_subclimate_global),   INTENT(INOUT) :: PD_obs_ocean
+    CHARACTER(LEN=*),               INTENT(IN)    :: name
+    
+    PD_obs_ocean%name = name 
+    PD_obs_ocean%netcdf%filename   = C%filename_PD_obs_ocean
+        
+    ! Inquire if all required variables are present in the NetCDF file, and read the grid size.
+    CALL allocate_shared_int_0D( PD_obs_ocean%nlon,     PD_obs_ocean%wnlon)
+    CALL allocate_shared_int_0D( PD_obs_ocean%nlat,     PD_obs_ocean%wnlat)
+    CALL allocate_shared_int_0D( PD_obs_ocean%nz_ocean, PD_obs_ocean%wnz_ocean)
+    IF (par%master) CALL inquire_PD_obs_data_file_ocean(PD_obs_ocean)
+    CALL sync
+    
+    ! Allocate memory  
+    CALL allocate_shared_dp_1D(                        PD_obs_ocean%nlon,                    PD_obs_ocean%lon,     PD_obs_ocean%wlon    )
+    CALL allocate_shared_dp_1D(                                           PD_obs_ocean%nlat, PD_obs_ocean%lat,     PD_obs_ocean%wlat    )
+    CALL allocate_shared_dp_1D( PD_obs_ocean%nz_ocean,                                       PD_obs_ocean%z_ocean, PD_obs_ocean%wz_ocean)        
+    !CALL allocate_shared_dp_3D( PD_obs_ocean%nlon, PD_obs_ocean%nlat, PD_obs_ocean%nz_ocean, PD_obs_ocean%mask_ocean,      PD_obs_ocean%wmask_ocean     )
+    CALL allocate_shared_dp_3D( PD_obs_ocean%nlon, PD_obs_ocean%nlat, PD_obs_ocean%nz_ocean, PD_obs_ocean%T_ocean,     PD_obs_ocean%wT_ocean    )
+    CALL allocate_shared_dp_3D( PD_obs_ocean%nlon, PD_obs_ocean%nlat, PD_obs_ocean%nz_ocean, PD_obs_ocean%S_ocean,     PD_obs_ocean%wS_ocean    )
+     
+    ! Read data from the NetCDF file
+    IF (par%master) WRITE(0,*) '   Reading PD observed ocean data from file ', TRIM(PD_obs_ocean%netcdf%filename), '...'
+    IF (par%master) CALL read_PD_obs_data_file_ocean(PD_obs_ocean)
+    CALL sync
+      
+    ! Determine process domains
+    CALL partition_list( PD_obs_ocean%nlon, par%i, par%n, PD_obs_ocean%i1, PD_obs_ocean%i2)
+      
+  END SUBROUTINE initialise_PD_obs_ocean_fields  
+  SUBROUTINE initialise_ocean_snapshot( snapshot, name, nc_filename, CO2, orbit_time)
+    ! Allocate shared memory for the data fields of a GCM snapshot (stored in the climate matrix),
+    ! read them from the specified NetCDF file (latter only done by master process).
+     
+    IMPLICIT NONE
+      
+    ! In/output variables:
+    TYPE(type_subclimate_global),   INTENT(INOUT) :: snapshot
+    CHARACTER(LEN=*),               INTENT(IN)    :: name
+    CHARACTER(LEN=*),               INTENT(IN)    :: nc_filename
+    REAL(dp),                       INTENT(IN)    :: CO2
+    REAL(dp),                       INTENT(IN)    :: orbit_time
+    
+    
+    ! Metadata
+    snapshot%name            = name 
+    snapshot%netcdf%filename = nc_filename
+    
+    ! General forcing info
+    CALL allocate_shared_dp_0D( snapshot%CO2,        snapshot%wCO2       )
+    CALL allocate_shared_dp_0D( snapshot%orbit_time, snapshot%worbit_time)
+    CALL allocate_shared_dp_0D( snapshot%orbit_ecc,  snapshot%worbit_ecc )
+    CALL allocate_shared_dp_0D( snapshot%orbit_obl,  snapshot%worbit_obl )
+    CALL allocate_shared_dp_0D( snapshot%orbit_pre,  snapshot%worbit_pre )
+    
+    snapshot%CO2        = CO2
+    snapshot%orbit_time = orbit_time
+    
+    ! Inquire if all required variables are present in the NetCDF file, and read the grid size.
+    CALL allocate_shared_int_0D( snapshot%nlon,     snapshot%wnlon)
+    CALL allocate_shared_int_0D( snapshot%nlat,     snapshot%wnlat)
+    CALL allocate_shared_int_0D( snapshot%nz_ocean, snapshot%wnz_ocean)
+    IF (par%master) CALL inquire_GCM_ocean_snapshot( snapshot)
+    CALL sync
+    
+    ! Allocate memory  
+    CALL allocate_shared_dp_1D(                        snapshot%nlon,                    snapshot%lon,     snapshot%wlon    )
+    CALL allocate_shared_dp_1D(                                           snapshot%nlat, snapshot%lat,     snapshot%wlat    )
+    CALL allocate_shared_dp_1D( snapshot%nz_ocean,                                       snapshot%z_ocean, snapshot%wz_ocean)        
+    !CALL allocate_shared_dp_3D( snapshot%nlon, snapshot%nlat, snapshot%nz_ocean, snapshot%mask_ocean,      snapshot%wmask_ocean     )
+    CALL allocate_shared_dp_3D( snapshot%nlon, snapshot%nlat, snapshot%nz_ocean, snapshot%T_ocean,     snapshot%wT_ocean    )
+    CALL allocate_shared_dp_3D( snapshot%nlon, snapshot%nlat, snapshot%nz_ocean, snapshot%S_ocean,     snapshot%wS_ocean    )
+    
+    ! Read data from the NetCDF file
+    IF (par%master) WRITE(0,*) '   Reading GCM ocean snapshot ', TRIM(snapshot%name), ' from file ', TRIM(snapshot%netcdf%filename), '...'
+    IF (par%master) CALL read_GCM_ocean_snapshot( snapshot)
+    CALL sync
+      
+    ! Determine process domains
+    CALL partition_list( snapshot%nlon, par%i, par%n, snapshot%i1, snapshot%i2)
+    
+    
+  END SUBROUTINE initialise_ocean_snapshot
   
 ! == Initialising the region-specific ocean data
   SUBROUTINE initialise_oceans_regional( grid, ice, climate, matrix)
@@ -68,6 +361,7 @@ CONTAINS
     ! Exception for schematic ocean temperature/salinity profile
     ! Set oceans to the ISOMIP+ "COLD" or "WARM" profile
     IF (C%choice_ocean_temperature_model == 'schematic') THEN
+      IF (par%master) WRITE(*,*) '    Schematic"', TRIM(C%choice_schematic_ocean), '" ocean forcing used for BMB forcing!'
       IF     (C%choice_schematic_ocean == 'MISMIPplus_WARM') THEN
         CALL set_ocean_to_ISOMIPplus_WARM( grid, climate%PD_obs  )
         CALL set_ocean_to_ISOMIPplus_WARM( grid, climate%GCM_PI  )
@@ -104,16 +398,19 @@ CONTAINS
       IF (par%master) WRITE(*,*) '    Constant present-day ocean forcing used for BMB forcing!'
     ELSE IF (C%choice_ocean_temperature_model == 'PI' .OR. C%choice_ocean_temperature_model == 'scaled')  THEN
       IF (par%master) WRITE(*,*) '    Ocean forcing initialised, but not actually used for BMB forcing!'
-    ELSE IF (C%choice_ocean_temperature_model == 'matrix_warm_cold') THEN      
+    ELSE IF (C%choice_ocean_temperature_model == 'matrix_warm_cold') THEN    
       CALL allocate_subclimate_regional_oceans( grid, climate%GCM_PI,   matrix%PD_obs_ocean%z_ocean, matrix%PD_obs_ocean%nz_ocean)
       CALL allocate_subclimate_regional_oceans( grid, climate%GCM_cold, matrix%PD_obs_ocean%z_ocean, matrix%PD_obs_ocean%nz_ocean)
       CALL allocate_subclimate_regional_oceans( grid, climate%GCM_warm, matrix%PD_obs_ocean%z_ocean, matrix%PD_obs_ocean%nz_ocean)
     
-      ! Map ocean data from the global subclimates to the regional subclimates
+      ! Map ocean data from the global subclimates to the regional subclimates, and extend the ocean data over the whole grid
       ! TODO: z-coordinate interpolation    
-      CALL map_ocean_data_global_to_regional( grid, matrix%GCM_PI,       climate%GCM_PI  )
-      CALL map_ocean_data_global_to_regional( grid, matrix%GCM_cold,     climate%GCM_cold)
-      CALL map_ocean_data_global_to_regional( grid, matrix%GCM_warm,     climate%GCM_warm)
+      CALL map_ocean_data_global_to_regional( grid, matrix%GCM_PI_ocean,       climate%GCM_PI  )
+      CALL extend_ocean_data_to_cover_grid ( grid, climate%GCM_PI, ice )
+      CALL map_ocean_data_global_to_regional( grid, matrix%GCM_cold_ocean,     climate%GCM_cold)
+      CALL extend_ocean_data_to_cover_grid ( grid, climate%GCM_cold, ice )
+      CALL map_ocean_data_global_to_regional( grid, matrix%GCM_warm_ocean,     climate%GCM_warm)
+      CALL extend_ocean_data_to_cover_grid ( grid, climate%GCM_warm, ice )
     
       ! Correct regional ocean data for GCM bias
       CALL correct_GCM_bias_ocean( grid, climate, climate%GCM_PI)
@@ -202,10 +499,12 @@ CONTAINS
     clim_reg%T_ocean_ext      = clim_reg%T_ocean
     clim_reg%S_ocean_ext      = clim_reg%S_ocean
     
-    DO l=1,45
-      WRITE(*,*) "l=",l
-      CALL extend_Gaussian_3D ( grid, clim_reg%T_ocean_ext, 8000._dp, 12000._dp, 67, ice%basin_ID) ! TODO: 67 -> clim_reg%nz_ocean
-      CALL extend_Gaussian_3D ( grid, clim_reg%S_ocean_ext, 8000._dp, 12000._dp, 67, ice%basin_ID) ! TODO: 67 -> clim_reg%nz_ocean
+    DO l=1,50 ! Random number of iterations
+      WRITE(*,*) "Climate=", TRIM(clim_reg%name), ", l=",l
+      !CALL extend_Gaussian_3D ( grid, clim_reg%T_ocean_ext, 8000._dp, 12000._dp, 67, ice%basin_ID) ! TODO: 67 -> clim_reg%nz_ocean
+      !CALL extend_Gaussian_3D ( grid, clim_reg%S_ocean_ext, 8000._dp, 12000._dp, 67, ice%basin_ID) ! TODO: 67 -> clim_reg%nz_ocean
+      CALL extend_Gaussian_3D ( grid, clim_reg%T_ocean_ext, 8000._dp, 12000._dp, 40, ice%basin_ID) ! TODO: 40 -> clim_reg%nz_ocean
+      CALL extend_Gaussian_3D ( grid, clim_reg%S_ocean_ext, 8000._dp, 12000._dp, 40, ice%basin_ID) ! TODO: 40 -> clim_reg%nz_ocean
       
       CALL check_for_NaN_dp_2D_return ( clim_reg%T_ocean_ext(1,:,:) ,check ) 
       !WRITE(*,*) 'check=',check
@@ -232,50 +531,10 @@ CONTAINS
     TYPE(type_subclimate_region),        INTENT(INOUT) :: subclimate
     
     subclimate%T_ocean_corr_ext = subclimate%T_ocean_ext - (climate%GCM_PI%T_ocean_ext - climate%PD_obs%T_ocean_ext)
-    subclimate%T_ocean_corr_ext = subclimate%S_ocean_ext - (climate%GCM_PI%S_ocean_ext - climate%PD_obs%S_ocean_ext)
-       
+    subclimate%s_ocean_corr_ext = subclimate%S_ocean_ext - (climate%GCM_PI%S_ocean_ext - climate%PD_obs%S_ocean_ext)       
   
   END SUBROUTINE correct_GCM_bias_ocean
-  
-
-  ! Allocate shared memory for the global PD observed ocean data fields (stored in the climate matrix),
-  ! read them from the specified NetCDF file (latter only done by master process).  
-  SUBROUTINE initialise_PD_obs_ocean_fields (PD_obs_ocean, name)
-     
-    IMPLICIT NONE
-      
-    ! Input variables:
-    TYPE(type_subclimate_global),   INTENT(INOUT) :: PD_obs_ocean
-    CHARACTER(LEN=*),               INTENT(IN)    :: name
     
-    PD_obs_ocean%name = name 
-    PD_obs_ocean%netcdf%filename   = C%filename_PD_obs_ocean
-        
-    ! Inquire if all required variables are present in the NetCDF file, and read the grid size.
-    CALL allocate_shared_int_0D( PD_obs_ocean%nlon,     PD_obs_ocean%wnlon)
-    CALL allocate_shared_int_0D( PD_obs_ocean%nlat,     PD_obs_ocean%wnlat)
-    CALL allocate_shared_int_0D( PD_obs_ocean%nz_ocean, PD_obs_ocean%wnz_ocean)
-    IF (par%master) CALL inquire_PD_obs_data_file_ocean(PD_obs_ocean)
-    CALL sync
-    
-    ! Allocate memory  
-    CALL allocate_shared_dp_1D(                        PD_obs_ocean%nlon,                    PD_obs_ocean%lon,     PD_obs_ocean%wlon    )
-    CALL allocate_shared_dp_1D(                                           PD_obs_ocean%nlat, PD_obs_ocean%lat,     PD_obs_ocean%wlat    )
-    CALL allocate_shared_dp_1D( PD_obs_ocean%nz_ocean,                                       PD_obs_ocean%z_ocean, PD_obs_ocean%wz_ocean)        
-    !CALL allocate_shared_dp_3D( PD_obs_ocean%nlon, PD_obs_ocean%nlat, PD_obs_ocean%nz_ocean, PD_obs_ocean%mask_ocean,      PD_obs_ocean%wPrecip     )
-    CALL allocate_shared_dp_3D( PD_obs_ocean%nlon, PD_obs_ocean%nlat, PD_obs_ocean%nz_ocean, PD_obs_ocean%T_ocean,     PD_obs_ocean%wT_ocean    )
-    CALL allocate_shared_dp_3D( PD_obs_ocean%nlon, PD_obs_ocean%nlat, PD_obs_ocean%nz_ocean, PD_obs_ocean%S_ocean,     PD_obs_ocean%wS_ocean    )
-     
-    ! Read data from the NetCDF file
-    IF (par%master) WRITE(0,*) '   Reading PD observed ocean data from file ', TRIM(PD_obs_ocean%netcdf%filename), '...'
-    IF (par%master) CALL read_PD_obs_data_file_ocean(PD_obs_ocean)
-    CALL sync
-      
-    ! Determine process domains
-    CALL partition_list( PD_obs_ocean%nlon, par%i, par%n, PD_obs_ocean%i1, PD_obs_ocean%i2)
-      
-  END SUBROUTINE initialise_PD_obs_ocean_fields
-  
 ! == Some schematic ocean temperature/salinity profiles
   SUBROUTINE MISOMIP1_ocean_profiles( grid, climate, time)
     ! Set the ocean temperature and salinity according to the ISOMIP+ protocol

--- a/src/ocean_module.f90
+++ b/src/ocean_module.f90
@@ -78,7 +78,7 @@ CONTAINS
   ! =======================================================
     
     
-    IF (C%choice_ocean_temperature_model == 'PI' .OR. &
+    IF (C%choice_ocean_temperature_model == 'fixed' .OR. &
         C%choice_ocean_temperature_model == 'scaled' .OR. &
         C%choice_ocean_temperature_model == 'schematic' .OR. &
         C%choice_ocean_temperature_model == 'WOA') THEN
@@ -211,7 +211,7 @@ CONTAINS
     CALL initialise_PD_obs_ocean_fields ( matrix%PD_obs_ocean, 'WOA18')
     
     ! The different GCM snapshots 
-    IF ((C%choice_ocean_temperature_model == 'PI') .OR. (C%choice_ocean_temperature_model == 'scaled') .OR. &
+    IF ((C%choice_ocean_temperature_model == 'fixed') .OR. (C%choice_ocean_temperature_model == 'scaled') .OR. &
         (C%choice_ocean_temperature_model == 'schematic') .OR. (C%choice_ocean_temperature_model == 'WOA')) THEN
       ! These choices of forcing don't use any GCM (snapshot) ocean data
       RETURN
@@ -396,7 +396,7 @@ CONTAINS
     
     IF (C%choice_ocean_temperature_model == 'WOA') THEN
       IF (par%master) WRITE(*,*) '    Constant present-day ocean forcing used for BMB forcing!'
-    ELSE IF (C%choice_ocean_temperature_model == 'PI' .OR. C%choice_ocean_temperature_model == 'scaled')  THEN
+    ELSE IF (C%choice_ocean_temperature_model == 'fixed' .OR. C%choice_ocean_temperature_model == 'scaled')  THEN
       IF (par%master) WRITE(*,*) '    Ocean forcing initialised, but not actually used for BMB forcing!'
     ELSE IF (C%choice_ocean_temperature_model == 'matrix_warm_cold') THEN    
       CALL allocate_subclimate_regional_oceans( grid, climate%GCM_PI,   matrix%PD_obs_ocean%z_ocean, matrix%PD_obs_ocean%nz_ocean)
@@ -509,11 +509,7 @@ CONTAINS
       CALL check_for_NaN_dp_2D_return ( clim_reg%T_ocean_ext(1,:,:) ,check ) 
       !WRITE(*,*) 'check=',check
 
-    END DO
-    
-    !CALL extend_Gaussian_3D ( grid, clim_reg%T_ocean_ext, 1250000._dp, 2500000._dp, 67, ice%basin_ID)
-    !CALL extend_Gaussian_3D ( grid, clim_reg%S_ocean_ext, 1250000._dp, 2500000._dp, 67, ice%basin_ID)
-    
+    END DO    
     ! Initialize the final bias-corrected value. Bias correction will follow later for the climates where this is desired.
     clim_reg%T_ocean_corr_ext      = clim_reg%T_ocean_ext
     clim_reg%S_ocean_corr_ext      = clim_reg%S_ocean_ext


### PR DESCRIPTION
This commit enables the use of ocean data (temp. & salinity) from
GCM snapshots to calculate the ocean forcing for the BMB routines,
similar to the climate matrix method. Option C%choice_temperature_model
should be set to 'matrix_warm_cold'.

Everything related to the ocean forcing now happens in the ocean_module.
Probably, some thought still has to be given to how to interpolate
between the snaphots. For now, a scalar weight related to CO2, and a sca-
lar weight related to the surface height, can be linearly combined using
the newly included C%ocean_matrix_CO2vsice_<region> factors (by default
set to 1, meaning pure CO2-based forcing).