### PR TITLE
Calving upgrade

### DIFF
--- a/MISMIP_mod_spinup_40km/config_MISMIP_mod_spinup_40km
+++ b/MISMIP_mod_spinup_40km/config_MISMIP_mod_spinup_40km
@@ -1,0 +1,236 @@
+&CONFIG
+
+  ! Time steps and range
+  ! ====================
+  
+start_time_of_run_config                    = 0.0                              ! Start time (in years) of the simulations
+end_time_of_run_config                      = 50000.0                          ! End   time (in years) of the simulations
+dt_coupling_config                          = 100.0                            ! Interval of coupling (in years) between the four ice-sheets  
+dt_max_config                               = 10.0                             ! Maximum time step (in years) of the ice model
+dt_thermo_config                            = 10.0                             ! Time step (in years) for updating thermodynamics
+dt_climate_config                           = 10.0                             ! Time step (in years) for updating the climate
+dt_ocean_config                             = 10.0                             ! Time step (in years) for updating the ocean
+dt_SMB_config                               = 10.0                             ! Time step (in years) for updating the SMB
+dt_BMB_config                               = 10.0                             ! Time step (in years) for updating the BMB
+dt_bedrock_ELRA_config                      = 100.0                            ! Time step (in years) for updating the bedrock deformation rate with the ELRA model
+dt_SELEN_config                             = 1000.0                           ! Time step (in years) for calling SELEN
+dt_output_config                            = 5000.0                           ! Time step (in years) for writing output
+  
+  ! Which ice sheets do we simulate?
+  ! ================================
+  
+do_NAM_config                               = .FALSE.                          ! North America
+do_EAS_config                               = .FALSE.                          ! Eurasia
+do_GRL_config                               = .FALSE.                          ! Greenland
+do_ANT_config                               = .TRUE.                           ! Antarctica
+
+  ! Whether or not to let IMAU_ICE dynamically create its own output folder.
+  ! This works fine locally, on LISA its better to use a fixed folder name.
+  ! =======================================================================
+  
+create_procedural_output_dir_config         = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+fixed_output_dir_config                     = 'MISMIP_mod_spinup_40km'         ! If not, create a directory with this name instead (stops the program if this directory already exists)
+fixed_output_dir_suffix_config              = ''                               ! Suffix to put after the fixed output directory name, useful when doing ensemble runs with the template+variation set-up
+do_write_regional_scalar_output_config      = .TRUE.
+do_write_global_scalar_output_config        = .TRUE.
+  
+  ! Debugging
+  ! =========
+  
+do_write_debug_data_config                  = .TRUE.                           ! Whether or not the debug NetCDF file should be created and written to
+do_check_for_NaN_config                     = .FALSE.                          ! Whether or not fields should be checked for NaN values                           
+  
+  ! Horizontal grid spacing and size for the four regions
+  ! =====================================================
+  
+xmin_ANT_config                             = -1500000.0                       ! Western  boundary     of the Antarctica domain [m]
+xmax_ANT_config                             =  1500000.0                       ! Eastern  boundary     of the Antarctica domain [m]
+ymin_ANT_config                             = -1500000.0                       ! Southern boundary     of the Antarctica domain [m]
+ymax_ANT_config                             =  1500000.0                       ! Northern boundary     of the Antarctica domain [m]
+dx_ANT_config                               = 40000.0                          ! Horizontal resolution of the Antarctica domain [m]
+
+  ! Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ================================================================
+  
+  ! Initial geometry
+choice_refgeo_init_ANT_config               = 'idealised'           ! Choice of initial geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+choice_refgeo_init_idealised_config         = 'MISMIP_mod'          ! Choice of schematic initial geometry; see "generate_idealised_geometry" in reference_fields_module for options
+  
+  ! Present-day geometry
+choice_refgeo_PD_ANT_config                 = 'idealised'           ! Choice of present-day geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+choice_refgeo_PD_idealised_config           = 'MISMIP_mod'          ! Choice of schematic present-day geometry; see "generate_idealised_geometry" in reference_fields_module for options
+  
+  ! GIA equilibrium geometry
+choice_refgeo_GIAeq_ANT_config              = 'idealised'           ! Choice of GIA equilibrium geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+choice_refgeo_GIAeq_idealised_config        = 'MISMIP_mod'          ! Choice of schematic GIA equilibrium geometry; see "generate_idealised_geometry" in reference_fields_module for options
+
+remove_Lake_Vostok_config                   = .TRUE.
+  
+  ! Global forcing (insolation, CO2, d18O, geothermal heat flux)
+  ! ============================================================
+  
+  ! Possible choice_forcing_method options:
+  ! 'none'                 : No global forcing used at all; climate or SMB are fully parameterised or directly prescribed
+  ! 'd18O_inverse_dT_glob' : Use the inverse routine with the specified d18O record to calculate a global temperature offset (e.g. de Boer et al., 2013)
+  ! 'CO2_direct'           : Use the specified CO2 record to force the climate matrix (e.g. Berends et al., 2018)
+  ! 'd18O_inverse_CO2'     : Use the inverse routine with the specified d18O record to calculate CO2 and then force the climate matrix (e.g. Berends et al., 2019)
+choice_forcing_method_config                = 'none' 
+   
+  ! Insolation forcing (NetCDF)
+choice_insolation_forcing_config            = 'none'                           ! Choice of insolation forcing: "none", "static", "realistic"
+  
+  ! Geothermal heat flux
+choice_geothermal_heat_flux_config          = 'constant'                       ! Choice of geothermal heat flux; can be 'constant' or 'spatial'
+constant_geothermal_heat_flux_config        = 0.0                              ! Geothermal Heat flux [J m^-2 yr^-1] Sclater et al. (1980)
+
+  ! Parameters for calculating modelled benthic d18O
+do_calculate_benthic_d18O_config            = .FALSE.                          ! Whether or not to calculate modelled benthic d18O (set to .FALSE. for e.g. idealised-geometry experiments, future projections)
+
+  ! Ice dynamics - velocity
+  ! =======================
+  
+choice_ice_dynamics_config                  = 'DIVA'                           ! Choice of ice-dynamica approximation: "none" (= fixed geometry), "SIA", "SSA", "SIA/SSA", "DIVA"
+n_flow_config                               = 3.0                              ! Exponent in Glen's flow law
+m_enh_sheet_config                          = 1.0                              ! Ice flow enhancement factor for grounded ice
+m_enh_shelf_config                          = 1.0                              ! Ice flow enhancement factor for floating ice
+choice_ice_margin_config                    = 'infinite_slab'                  ! Choice of ice margin boundary conditions: "BC", "infinite_slab"
+include_SSADIVA_crossterms_config           = .TRUE.                           ! Whether or not to include the "cross-terms" of the SSA/DIVA
+do_GL_subgrid_friction_config               = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+do_smooth_geometry_config                   = .FALSE.                          ! Whether or not to smooth the model geometry (bedrock + initial ice thickness)
+r_smooth_geometry_config                    = 0.5                              ! Geometry smoothing radius (in number of grid cells)
+  
+  ! Ice thickness boundary conditions
+choice_mask_noice_ANT_config                = 'MISMIP_mod'                     ! For Antarctica, additional choices are included for certain idealised-geometry experiments: "MISMIP_mod", "MISMIP+"
+
+  ! Ice dynamics - basal conditions and sliding
+  ! ===========================================
+  
+  ! Sliding laws
+choice_sliding_law_config                   = 'Coulomb_regularised'            ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Coulomb_regularised", "Weertman", "Tsai2015", "Schoof2005"
+slid_delta_v_config                         = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+slid_Weertman_m_config                      = 3.0                              ! Exponent in Weertman sliding law
+slid_Coulomb_reg_q_plastic_config           = 0.3                              ! Scaling exponent   in regularised Coulomb sliding law
+slid_Coulomb_reg_u_threshold_config         = 100.0                            ! Threshold velocity in regularised Coulomb sliding law
+  
+  ! Basal conditions
+choice_basal_conditions_config              = 'Martin2011'                     ! Choice of basal conditions: "idealised", "Martin2011"
+Martin2011till_pwp_Hb_min_config            = 0.0                              ! Martin et al. (2011) till model: low-end  Hb  value of bedrock-dependent pore-water pressure
+Martin2011till_pwp_Hb_max_config            = 1000.0                           ! Martin et al. (2011) till model: high-end Hb  value of bedrock-dependent pore-water pressure
+Martin2011till_phi_Hb_min_config            = -1000.0                          ! Martin et al. (2011) till model: low-end  Hb  value of bedrock-dependent till friction angle
+Martin2011till_phi_Hb_max_config            = 0.0                              ! Martin et al. (2011) till model: high-end Hb  value of bedrock-dependent till friction angle
+Martin2011till_phi_min_config               = 5.0                              ! Martin et al. (2011) till model: low-end  phi value of bedrock-dependent till friction angle
+Martin2011till_phi_max_config               = 20.0                             ! Martin et al. (2011) till model: high-end phi value of bedrock-dependent till friction angle
+
+  ! Ice dynamics - calving
+  ! ======================
+  
+choice_calving_law_config                   = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+calving_threshold_thickness_config          = 200.0                            ! Threshold ice thickness in the "threshold_thickness" calving law (200m taken from ANICE)
+  
+  ! Thermodynamics and rheology
+  ! ===========================
+  
+choice_initial_ice_temperature_config       = 'uniform'                        ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "restart"
+uniform_ice_temperature_config              = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+choice_thermo_model_config                  = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+choice_ice_rheology_config                  = 'uniform'                        ! Choice of ice rheology model: "uniform", "Huybrechts1992", "MISMIP_mod"
+uniform_flow_factor_config                  = 1E-16                            ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+choice_ice_heat_capacity_config             = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+uniform_ice_heat_capacity_config            = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+choice_ice_thermal_conductivity_config      = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+uniform_ice_thermal_conductivity_config     = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+  
+  ! Climate
+  ! =======
+
+choice_climate_model_config                 = 'none'                           ! Choice of climate model: "none", "idealised", "PD_obs", "PD_dTglob", "matrix_warm_cold", "direct_global", "direct_regional"
+  
+  ! Ocean
+  ! =====
+  
+choice_ocean_model_config                   = 'none'                           ! Choice of ocean model: "none", "idealised", "uniform_warm_cold", "PD_obs", "matrix_warm_cold"  
+  
+  ! Surface mass balance
+  ! ====================
+  
+choice_SMB_model_config                     = 'uniform'                        ! Choice of SMB model: "uniform", "idealised", "IMAU-ITM", "direct_global", "direct_regional"
+SMB_uniform_config                          = 0.3                              ! Uniform SMB, applied when choice_SMB_model = "uniform" [mie/yr] 
+  
+  ! Basal mass balance
+  ! ==================
+  
+choice_BMB_shelf_model_config               = 'uniform'                        ! Choice of shelf BMB: "uniform", "idealised", "ANICE_legacy", "Favier2019_lin", "Favier2019_quad", "Favier2019_Mplus", "Lazeroms2018_plume", "PICO", "PICOP"
+choice_BMB_sheet_model_config               = 'uniform'                        ! Choice of sheet BMB: "uniform"
+BMB_shelf_uniform_config                    = 0.0                              ! Uniform shelf BMB, applied when choice_BMB_shelf_model = "uniform" [mie/yr]
+BMB_sheet_uniform_config                    = 0.0                              ! Uniform sheet BMB, applied when choice_BMB_sheet_model = "uniform" [mie/yr]
+choice_BMB_subgrid_config                   = 'FCMP'                           ! Choice of sub-grid BMB scheme: "FCMP", "PMP", "NMP" (following Leguy et al., 2021)
+  
+  ! Englacial isotope tracing
+  ! =========================
+  
+choice_ice_isotopes_model_config             = 'none'                          ! Choice of englacial isotopes model: "none", "uniform", "ANICE_legacy"
+    
+  ! Sea level and GIA
+  ! =================
+  
+do_ocean_floodfill_config                   = .FALSE.                          ! Use a flood-fill to determine the ocean mask, so that (pro-/sub-glacial) lakes dont exist
+choice_sealevel_model_config                = 'fixed'                          ! Can be "fixed", "prescribed", "eustatic", or "SELEN"
+fixed_sealevel_config                       = 0.0                              ! Height of fixed sealevel w.r.t. PD
+  
+choice_GIA_model_config                     = 'none'                           ! Can be "none", "ELRA", or "SELEN"
+  
+  ! Which data fields will be written to the help_fields output file
+  ! ================================================================
+  
+help_field_01_config                         = 'mask'
+help_field_02_config                         = 'uabs_vav'
+help_field_03_config                         = 'none'
+help_field_04_config                         = 'none'
+help_field_05_config                         = 'none'
+help_field_06_config                         = 'none'
+help_field_07_config                         = 'none'
+help_field_08_config                         = 'none'
+help_field_09_config                         = 'none'
+help_field_10_config                         = 'none'
+help_field_11_config                         = 'none'
+help_field_12_config                         = 'none'
+help_field_13_config                         = 'none'
+help_field_14_config                         = 'none'
+help_field_15_config                         = 'none'
+help_field_16_config                         = 'none'
+help_field_17_config                         = 'none'
+help_field_18_config                         = 'none'
+help_field_19_config                         = 'none'
+help_field_20_config                         = 'none'
+help_field_21_config                         = 'none'
+help_field_22_config                         = 'none'
+help_field_23_config                         = 'none'
+help_field_24_config                         = 'none'
+help_field_25_config                         = 'none'
+help_field_26_config                         = 'none'
+help_field_27_config                         = 'none'
+help_field_28_config                         = 'none'
+help_field_29_config                         = 'none'
+help_field_30_config                         = 'none'
+help_field_31_config                         = 'none'
+help_field_32_config                         = 'none'
+help_field_33_config                         = 'none'
+help_field_34_config                         = 'none'
+help_field_35_config                         = 'none'
+help_field_36_config                         = 'none'
+help_field_37_config                         = 'none'
+help_field_38_config                         = 'none'
+help_field_39_config                         = 'none'
+help_field_40_config                         = 'none'
+help_field_41_config                         = 'none'
+help_field_42_config                         = 'none'
+help_field_43_config                         = 'none'
+help_field_44_config                         = 'none'
+help_field_45_config                         = 'none'
+help_field_46_config                         = 'none'
+help_field_47_config                         = 'none'
+help_field_48_config                         = 'none'
+help_field_49_config                         = 'none'
+help_field_50_config                         = 'none'
+
+/

--- a/config-files/config_MISMIP_mod_spinup_40km
+++ b/config-files/config_MISMIP_mod_spinup_40km
@@ -1,0 +1,236 @@
+&CONFIG
+
+  ! Time steps and range
+  ! ====================
+  
+start_time_of_run_config                    = 0.0                              ! Start time (in years) of the simulations
+end_time_of_run_config                      = 50000.0                          ! End   time (in years) of the simulations
+dt_coupling_config                          = 100.0                            ! Interval of coupling (in years) between the four ice-sheets  
+dt_max_config                               = 10.0                             ! Maximum time step (in years) of the ice model
+dt_thermo_config                            = 10.0                             ! Time step (in years) for updating thermodynamics
+dt_climate_config                           = 10.0                             ! Time step (in years) for updating the climate
+dt_ocean_config                             = 10.0                             ! Time step (in years) for updating the ocean
+dt_SMB_config                               = 10.0                             ! Time step (in years) for updating the SMB
+dt_BMB_config                               = 10.0                             ! Time step (in years) for updating the BMB
+dt_bedrock_ELRA_config                      = 100.0                            ! Time step (in years) for updating the bedrock deformation rate with the ELRA model
+dt_SELEN_config                             = 1000.0                           ! Time step (in years) for calling SELEN
+dt_output_config                            = 5000.0                           ! Time step (in years) for writing output
+  
+  ! Which ice sheets do we simulate?
+  ! ================================
+  
+do_NAM_config                               = .FALSE.                          ! North America
+do_EAS_config                               = .FALSE.                          ! Eurasia
+do_GRL_config                               = .FALSE.                          ! Greenland
+do_ANT_config                               = .TRUE.                           ! Antarctica
+
+  ! Whether or not to let IMAU_ICE dynamically create its own output folder.
+  ! This works fine locally, on LISA its better to use a fixed folder name.
+  ! =======================================================================
+  
+create_procedural_output_dir_config         = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+fixed_output_dir_config                     = 'MISMIP_mod_spinup_40km'         ! If not, create a directory with this name instead (stops the program if this directory already exists)
+fixed_output_dir_suffix_config              = ''                               ! Suffix to put after the fixed output directory name, useful when doing ensemble runs with the template+variation set-up
+do_write_regional_scalar_output_config      = .TRUE.
+do_write_global_scalar_output_config        = .TRUE.
+  
+  ! Debugging
+  ! =========
+  
+do_write_debug_data_config                  = .TRUE.                           ! Whether or not the debug NetCDF file should be created and written to
+do_check_for_NaN_config                     = .FALSE.                          ! Whether or not fields should be checked for NaN values                           
+  
+  ! Horizontal grid spacing and size for the four regions
+  ! =====================================================
+  
+xmin_ANT_config                             = -1500000.0                       ! Western  boundary     of the Antarctica domain [m]
+xmax_ANT_config                             =  1500000.0                       ! Eastern  boundary     of the Antarctica domain [m]
+ymin_ANT_config                             = -1500000.0                       ! Southern boundary     of the Antarctica domain [m]
+ymax_ANT_config                             =  1500000.0                       ! Northern boundary     of the Antarctica domain [m]
+dx_ANT_config                               = 40000.0                          ! Horizontal resolution of the Antarctica domain [m]
+
+  ! Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ================================================================
+  
+  ! Initial geometry
+choice_refgeo_init_ANT_config               = 'idealised'           ! Choice of initial geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+choice_refgeo_init_idealised_config         = 'MISMIP_mod'          ! Choice of schematic initial geometry; see "generate_idealised_geometry" in reference_fields_module for options
+  
+  ! Present-day geometry
+choice_refgeo_PD_ANT_config                 = 'idealised'           ! Choice of present-day geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+choice_refgeo_PD_idealised_config           = 'MISMIP_mod'          ! Choice of schematic present-day geometry; see "generate_idealised_geometry" in reference_fields_module for options
+  
+  ! GIA equilibrium geometry
+choice_refgeo_GIAeq_ANT_config              = 'idealised'           ! Choice of GIA equilibrium geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+choice_refgeo_GIAeq_idealised_config        = 'MISMIP_mod'          ! Choice of schematic GIA equilibrium geometry; see "generate_idealised_geometry" in reference_fields_module for options
+
+remove_Lake_Vostok_config                   = .TRUE.
+  
+  ! Global forcing (insolation, CO2, d18O, geothermal heat flux)
+  ! ============================================================
+  
+  ! Possible choice_forcing_method options:
+  ! 'none'                 : No global forcing used at all; climate or SMB are fully parameterised or directly prescribed
+  ! 'd18O_inverse_dT_glob' : Use the inverse routine with the specified d18O record to calculate a global temperature offset (e.g. de Boer et al., 2013)
+  ! 'CO2_direct'           : Use the specified CO2 record to force the climate matrix (e.g. Berends et al., 2018)
+  ! 'd18O_inverse_CO2'     : Use the inverse routine with the specified d18O record to calculate CO2 and then force the climate matrix (e.g. Berends et al., 2019)
+choice_forcing_method_config                = 'none' 
+   
+  ! Insolation forcing (NetCDF)
+choice_insolation_forcing_config            = 'none'                           ! Choice of insolation forcing: "none", "static", "realistic"
+  
+  ! Geothermal heat flux
+choice_geothermal_heat_flux_config          = 'constant'                       ! Choice of geothermal heat flux; can be 'constant' or 'spatial'
+constant_geothermal_heat_flux_config        = 0.0                              ! Geothermal Heat flux [J m^-2 yr^-1] Sclater et al. (1980)
+
+  ! Parameters for calculating modelled benthic d18O
+do_calculate_benthic_d18O_config            = .FALSE.                          ! Whether or not to calculate modelled benthic d18O (set to .FALSE. for e.g. idealised-geometry experiments, future projections)
+
+  ! Ice dynamics - velocity
+  ! =======================
+  
+choice_ice_dynamics_config                  = 'DIVA'                           ! Choice of ice-dynamica approximation: "none" (= fixed geometry), "SIA", "SSA", "SIA/SSA", "DIVA"
+n_flow_config                               = 3.0                              ! Exponent in Glen's flow law
+m_enh_sheet_config                          = 1.0                              ! Ice flow enhancement factor for grounded ice
+m_enh_shelf_config                          = 1.0                              ! Ice flow enhancement factor for floating ice
+choice_ice_margin_config                    = 'infinite_slab'                  ! Choice of ice margin boundary conditions: "BC", "infinite_slab"
+include_SSADIVA_crossterms_config           = .TRUE.                           ! Whether or not to include the "cross-terms" of the SSA/DIVA
+do_GL_subgrid_friction_config               = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+do_smooth_geometry_config                   = .FALSE.                          ! Whether or not to smooth the model geometry (bedrock + initial ice thickness)
+r_smooth_geometry_config                    = 0.5                              ! Geometry smoothing radius (in number of grid cells)
+  
+  ! Ice thickness boundary conditions
+choice_mask_noice_ANT_config                = 'MISMIP_mod'                     ! For Antarctica, additional choices are included for certain idealised-geometry experiments: "MISMIP_mod", "MISMIP+"
+
+  ! Ice dynamics - basal conditions and sliding
+  ! ===========================================
+  
+  ! Sliding laws
+choice_sliding_law_config                   = 'Coulomb_regularised'            ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Coulomb_regularised", "Weertman", "Tsai2015", "Schoof2005"
+slid_delta_v_config                         = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+slid_Weertman_m_config                      = 3.0                              ! Exponent in Weertman sliding law
+slid_Coulomb_reg_q_plastic_config           = 0.3                              ! Scaling exponent   in regularised Coulomb sliding law
+slid_Coulomb_reg_u_threshold_config         = 100.0                            ! Threshold velocity in regularised Coulomb sliding law
+  
+  ! Basal conditions
+choice_basal_conditions_config              = 'Martin2011'                     ! Choice of basal conditions: "idealised", "Martin2011"
+Martin2011till_pwp_Hb_min_config            = 0.0                              ! Martin et al. (2011) till model: low-end  Hb  value of bedrock-dependent pore-water pressure
+Martin2011till_pwp_Hb_max_config            = 1000.0                           ! Martin et al. (2011) till model: high-end Hb  value of bedrock-dependent pore-water pressure
+Martin2011till_phi_Hb_min_config            = -1000.0                          ! Martin et al. (2011) till model: low-end  Hb  value of bedrock-dependent till friction angle
+Martin2011till_phi_Hb_max_config            = 0.0                              ! Martin et al. (2011) till model: high-end Hb  value of bedrock-dependent till friction angle
+Martin2011till_phi_min_config               = 5.0                              ! Martin et al. (2011) till model: low-end  phi value of bedrock-dependent till friction angle
+Martin2011till_phi_max_config               = 20.0                             ! Martin et al. (2011) till model: high-end phi value of bedrock-dependent till friction angle
+
+  ! Ice dynamics - calving
+  ! ======================
+  
+choice_calving_law_config                   = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+calving_threshold_thickness_config          = 200.0                            ! Threshold ice thickness in the "threshold_thickness" calving law (200m taken from ANICE)
+  
+  ! Thermodynamics and rheology
+  ! ===========================
+  
+choice_initial_ice_temperature_config       = 'uniform'                        ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "restart"
+uniform_ice_temperature_config              = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+choice_thermo_model_config                  = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+choice_ice_rheology_config                  = 'uniform'                        ! Choice of ice rheology model: "uniform", "Huybrechts1992", "MISMIP_mod"
+uniform_flow_factor_config                  = 1E-16                            ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+choice_ice_heat_capacity_config             = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+uniform_ice_heat_capacity_config            = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+choice_ice_thermal_conductivity_config      = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+uniform_ice_thermal_conductivity_config     = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+  
+  ! Climate
+  ! =======
+
+choice_climate_model_config                 = 'none'                           ! Choice of climate model: "none", "idealised", "PD_obs", "PD_dTglob", "matrix_warm_cold", "direct_global", "direct_regional"
+  
+  ! Ocean
+  ! =====
+  
+choice_ocean_model_config                   = 'none'                           ! Choice of ocean model: "none", "idealised", "uniform_warm_cold", "PD_obs", "matrix_warm_cold"  
+  
+  ! Surface mass balance
+  ! ====================
+  
+choice_SMB_model_config                     = 'uniform'                        ! Choice of SMB model: "uniform", "idealised", "IMAU-ITM", "direct_global", "direct_regional"
+SMB_uniform_config                          = 0.3                              ! Uniform SMB, applied when choice_SMB_model = "uniform" [mie/yr] 
+  
+  ! Basal mass balance
+  ! ==================
+  
+choice_BMB_shelf_model_config               = 'uniform'                        ! Choice of shelf BMB: "uniform", "idealised", "ANICE_legacy", "Favier2019_lin", "Favier2019_quad", "Favier2019_Mplus", "Lazeroms2018_plume", "PICO", "PICOP"
+choice_BMB_sheet_model_config               = 'uniform'                        ! Choice of sheet BMB: "uniform"
+BMB_shelf_uniform_config                    = 0.0                              ! Uniform shelf BMB, applied when choice_BMB_shelf_model = "uniform" [mie/yr]
+BMB_sheet_uniform_config                    = 0.0                              ! Uniform sheet BMB, applied when choice_BMB_sheet_model = "uniform" [mie/yr]
+choice_BMB_subgrid_config                   = 'FCMP'                           ! Choice of sub-grid BMB scheme: "FCMP", "PMP", "NMP" (following Leguy et al., 2021)
+  
+  ! Englacial isotope tracing
+  ! =========================
+  
+choice_ice_isotopes_model_config             = 'none'                          ! Choice of englacial isotopes model: "none", "uniform", "ANICE_legacy"
+    
+  ! Sea level and GIA
+  ! =================
+  
+do_ocean_floodfill_config                   = .FALSE.                          ! Use a flood-fill to determine the ocean mask, so that (pro-/sub-glacial) lakes dont exist
+choice_sealevel_model_config                = 'fixed'                          ! Can be "fixed", "prescribed", "eustatic", or "SELEN"
+fixed_sealevel_config                       = 0.0                              ! Height of fixed sealevel w.r.t. PD
+  
+choice_GIA_model_config                     = 'none'                           ! Can be "none", "ELRA", or "SELEN"
+  
+  ! Which data fields will be written to the help_fields output file
+  ! ================================================================
+  
+help_field_01_config                         = 'mask'
+help_field_02_config                         = 'uabs_vav'
+help_field_03_config                         = 'none'
+help_field_04_config                         = 'none'
+help_field_05_config                         = 'none'
+help_field_06_config                         = 'none'
+help_field_07_config                         = 'none'
+help_field_08_config                         = 'none'
+help_field_09_config                         = 'none'
+help_field_10_config                         = 'none'
+help_field_11_config                         = 'none'
+help_field_12_config                         = 'none'
+help_field_13_config                         = 'none'
+help_field_14_config                         = 'none'
+help_field_15_config                         = 'none'
+help_field_16_config                         = 'none'
+help_field_17_config                         = 'none'
+help_field_18_config                         = 'none'
+help_field_19_config                         = 'none'
+help_field_20_config                         = 'none'
+help_field_21_config                         = 'none'
+help_field_22_config                         = 'none'
+help_field_23_config                         = 'none'
+help_field_24_config                         = 'none'
+help_field_25_config                         = 'none'
+help_field_26_config                         = 'none'
+help_field_27_config                         = 'none'
+help_field_28_config                         = 'none'
+help_field_29_config                         = 'none'
+help_field_30_config                         = 'none'
+help_field_31_config                         = 'none'
+help_field_32_config                         = 'none'
+help_field_33_config                         = 'none'
+help_field_34_config                         = 'none'
+help_field_35_config                         = 'none'
+help_field_36_config                         = 'none'
+help_field_37_config                         = 'none'
+help_field_38_config                         = 'none'
+help_field_39_config                         = 'none'
+help_field_40_config                         = 'none'
+help_field_41_config                         = 'none'
+help_field_42_config                         = 'none'
+help_field_43_config                         = 'none'
+help_field_44_config                         = 'none'
+help_field_45_config                         = 'none'
+help_field_46_config                         = 'none'
+help_field_47_config                         = 'none'
+help_field_48_config                         = 'none'
+help_field_49_config                         = 'none'
+help_field_50_config                         = 'none'
+
+/

--- a/src/BMB_module.f90
+++ b/src/BMB_module.f90
@@ -89,18 +89,20 @@ CONTAINS
     DO i = grid%i1, grid%i2
     DO j = 1, grid%ny
     
+      amplification_factor = 1._dp
+    
       IF (C%choice_BMB_shelf_amplification == 'uniform') THEN
         amplification_factor = 1._dp
       ELSE IF (C%choice_BMB_shelf_amplification == 'basin') THEN
         IF (region_name == 'ANT') THEN
-          amplification_factor = C%basin_BMB_amplification_factor_ANT (ice%basin_ID( j,i))
+          amplification_factor = C%basin_BMB_amplification_factor_ANT( ice%basin_ID( j,i))
         ELSE IF (region_name == 'GRL') THEN
-          amplification_factor = C%basin_BMB_amplification_factor_GRL (ice%basin_ID( j,i))
+          amplification_factor = C%basin_BMB_amplification_factor_GRL( ice%basin_ID( j,i))
         ELSE
           amplification_factor = 1._dp
         END IF 
       ELSE
-        IF (par%master) WRITE(0,*) '  ERROR: choice_BMB_sheet_model "', TRIM(C%choice_BMB_shelf_amplification), '" not implemented in run_BMB_model!'
+        IF (par%master) WRITE(0,*) '  ERROR: choice_BMB_shelf_amplification "', TRIM(C%choice_BMB_shelf_amplification), '" not implemented in run_BMB_model!'
         CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
       END IF       
     
@@ -1243,8 +1245,8 @@ CONTAINS
       
   END SUBROUTINE initialise_BMB_model_ANICE_legacy
   
-  ! The Favier et al. (2019) sub-shelf melt parameterisations
-! ========================================
+! == The Favier et al. (2019) sub-shelf melt parameterisations
+! ============================================================
 
   SUBROUTINE run_BMB_model_Favier2019_linear(         grid, ice, ocean, BMB)
     ! Calculate sub-shelf melt with Favier et al. (2019) linear parameterisation
@@ -1500,8 +1502,8 @@ CONTAINS
       
   END SUBROUTINE initialise_BMB_model_Favier2019
   
-  ! The Lazeroms et al. (2018) quasi-2-D plume parameterisation
-! ========================================
+! == The Lazeroms et al. (2018) quasi-2-D plume parameterisation
+! ==============================================================
 
   SUBROUTINE run_BMB_model_Lazeroms2018_plume( grid, ice, ocean, BMB)
     ! Calculate basal melt using the quasi-2-D plume parameterisation by Lazeroms et al. (2018), following the equations in Appendix A
@@ -1960,8 +1962,8 @@ CONTAINS
       
   END SUBROUTINE initialise_BMB_model_Lazeroms2018_plume
   
-  ! The PICO ocean box model
-! ========================================
+! == The PICO ocean box model
+! ===========================
 
   SUBROUTINE run_BMB_model_PICO( grid, ice, ocean, BMB)
     ! Calculate basal melt using the PICO ocean box model
@@ -2535,8 +2537,8 @@ CONTAINS
       
   END SUBROUTINE initialise_BMB_model_PICO
   
-  ! The PICOP ocean box + plume model
-! ========================================
+! == The PICOP ocean box + plume model
+! ====================================
 
   SUBROUTINE run_BMB_model_PICOP( grid, ice, ocean, BMB)
     ! Calculate basal melt using the PICOP ocean box + plume model

--- a/src/basal_conditions_and_sliding_module.f90
+++ b/src/basal_conditions_and_sliding_module.f90
@@ -59,8 +59,6 @@ CONTAINS
     ! using the till model by Martin et al. (2011).
     ! 
     ! Only applicable when choice_sliding_law = "Coulomb" or "Coulomb_regularised"
-  
-    USE derivatives_and_grids_module,    ONLY: map_a_to_b_2D
 
     IMPLICIT NONE
 

--- a/src/calving_module.f90
+++ b/src/calving_module.f90
@@ -23,7 +23,7 @@ CONTAINS
 
   ! The main routine that's called from the IMAU_ICE_main_model
   SUBROUTINE apply_calving_law( grid, ice, refgeo_PD, refgeo_GIAeq)
-    ! Calculate the calving flux
+    ! Apply the selected calving law, plus some calving-related operations
 
     IMPLICIT NONE
 
@@ -49,16 +49,6 @@ CONTAINS
       RETURN
     END IF ! IF (C%do_remove_shelves) THEN
     
-    ! Apply the selected calving law
-    IF     (C%choice_calving_law == 'none') THEN
-      ! No calving at all
-    ELSEIF (C%choice_calving_law == 'threshold_thickness') THEN
-      CALL threshold_thickness_calving( grid, ice)
-    ELSE
-      IF (par%master) WRITE(0,*) '  ERROR: choice_calving_law "', TRIM(C%choice_calving_law), '" not implemented in calculate_calving_flux!'
-      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
-    END IF
-    
     ! If so specified, remove all floating ice beyond the present-day calving front
     IF (C%remove_shelves_larger_than_PD) THEN
       DO i = grid%i1, grid%i2
@@ -82,6 +72,16 @@ CONTAINS
       END DO
       CALL sync
     END IF ! IF (C%continental_shelf_calving) THEN
+    
+    ! Apply the selected calving law
+    IF     (C%choice_calving_law == 'none') THEN
+      ! No calving at all
+    ELSEIF (C%choice_calving_law == 'threshold_thickness') THEN
+      CALL threshold_thickness_calving( grid, ice)
+    ELSE
+      IF (par%master) WRITE(0,*) '  ERROR: choice_calving_law "', TRIM(C%choice_calving_law), '" not implemented in calculate_calving_flux!'
+      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+    END IF
     
   END SUBROUTINE apply_calving_law
   

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -132,37 +132,37 @@ MODULE configuration_module
   ! ================================================================
   
   ! Initial geometry
-  CHARACTER(LEN=256)  :: choice_refgeo_init_NAM_config               = 'realistic'           ! Choice of initial geometry for North America; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_init_EAS_config               = 'realistic'           ! Choice of initial geometry for Eurasia      ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_init_GRL_config               = 'realistic'           ! Choice of initial geometry for Greenland    ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_init_ANT_config               = 'realistic'           ! Choice of initial geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
-  REAL(dp)            :: time_to_restart_from_NAM_config             = 0._dp                 ! Can be different from C%start_time_of_run, though this will issue a warning
+  CHARACTER(LEN=256)  :: choice_refgeo_init_NAM_config               = 'realistic'                      ! Choice of initial geometry for North America; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_init_EAS_config               = 'realistic'                      ! Choice of initial geometry for Eurasia      ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_init_GRL_config               = 'realistic'                      ! Choice of initial geometry for Greenland    ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_init_ANT_config               = 'realistic'                      ! Choice of initial geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+  REAL(dp)            :: time_to_restart_from_NAM_config             = 0._dp                            ! Can be different from C%start_time_of_run, though this will issue a warning
   REAL(dp)            :: time_to_restart_from_EAS_config             = 0._dp
   REAL(dp)            :: time_to_restart_from_GRL_config             = 0._dp
   REAL(dp)            :: time_to_restart_from_ANT_config             = 0._dp
-  CHARACTER(LEN=256)  :: choice_refgeo_init_idealised_config         = 'flatearth'           ! Choice of schematic initial geometry; see "generate_idealised_geometry" in reference_fields_module for options
+  CHARACTER(LEN=256)  :: choice_refgeo_init_idealised_config         = 'flatearth'                      ! Choice of schematic initial geometry; see "generate_idealised_geometry" in reference_fields_module for options
   CHARACTER(LEN=256)  :: filename_refgeo_init_NAM_config             = '/Users/berends/Documents/Datasets/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_init_EAS_config             = '/Users/berends/Documents/Datasets/ETOPO1/Eurasia_ETOPO1_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_init_GRL_config             = '/Users/berends/Documents/Datasets/Bedmachine_Greenland/Greenland_BedMachine_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_init_ANT_config             = '/Users/berends/Documents/Datasets/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
   
   ! Present-day geometry
-  CHARACTER(LEN=256)  :: choice_refgeo_PD_NAM_config                 = 'realistic'           ! Choice of present-day geometry for North America; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_PD_EAS_config                 = 'realistic'           ! Choice of present-day geometry for Eurasia      ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_PD_GRL_config                 = 'realistic'           ! Choice of present-day geometry for Greenland    ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_PD_ANT_config                 = 'realistic'           ! Choice of present-day geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_PD_idealised_config           = 'flatearth'           ! Choice of schematic present-day geometry; see "generate_idealised_geometry" in reference_fields_module for options
+  CHARACTER(LEN=256)  :: choice_refgeo_PD_NAM_config                 = 'realistic'                      ! Choice of present-day geometry for North America; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_PD_EAS_config                 = 'realistic'                      ! Choice of present-day geometry for Eurasia      ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_PD_GRL_config                 = 'realistic'                      ! Choice of present-day geometry for Greenland    ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_PD_ANT_config                 = 'realistic'                      ! Choice of present-day geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_PD_idealised_config           = 'flatearth'                      ! Choice of schematic present-day geometry; see "generate_idealised_geometry" in reference_fields_module for options
   CHARACTER(LEN=256)  :: filename_refgeo_PD_NAM_config               = '/Users/berends/Documents/Datasets/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_PD_EAS_config               = '/Users/berends/Documents/Datasets/ETOPO1/Eurasia_ETOPO1_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_PD_GRL_config               = '/Users/berends/Documents/Datasets/Bedmachine_Greenland/Greenland_BedMachine_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_PD_ANT_config               = '/Users/berends/Documents/Datasets/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
   
   ! GIA equilibrium geometry
-  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_NAM_config              = 'realistic'           ! Choice of GIA equilibrium geometry for North America; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_EAS_config              = 'realistic'           ! Choice of GIA equilibrium geometry for Eurasia      ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_GRL_config              = 'realistic'           ! Choice of GIA equilibrium geometry for Greenland    ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_ANT_config              = 'realistic'           ! Choice of GIA equilibrium geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
-  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_idealised_config        = 'flatearth'           ! Choice of schematic GIA equilibrium geometry; see "generate_idealised_geometry" in reference_fields_module for options
+  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_NAM_config              = 'realistic'                      ! Choice of GIA equilibrium geometry for North America; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_EAS_config              = 'realistic'                      ! Choice of GIA equilibrium geometry for Eurasia      ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_GRL_config              = 'realistic'                      ! Choice of GIA equilibrium geometry for Greenland    ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_ANT_config              = 'realistic'                      ! Choice of GIA equilibrium geometry for Antarctica   ; can be "idealised", "realistic", or "restart"
+  CHARACTER(LEN=256)  :: choice_refgeo_GIAeq_idealised_config        = 'flatearth'                      ! Choice of schematic GIA equilibrium geometry; see "generate_idealised_geometry" in reference_fields_module for options
   CHARACTER(LEN=256)  :: filename_refgeo_GIAeq_NAM_config            = '/Users/berends/Documents/Datasets/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_GIAeq_EAS_config            = '/Users/berends/Documents/Datasets/ETOPO1/Eurasia_ETOPO1_5km.nc'
   CHARACTER(LEN=256)  :: filename_refgeo_GIAeq_GRL_config            = '/Users/berends/Documents/Datasets/Bedmachine_Greenland/Greenland_BedMachine_5km.nc'
@@ -302,12 +302,12 @@ MODULE configuration_module
   ! Ice dynamics - calving
   ! ======================
   
-  CHARACTER(LEN=256)  :: choice_calving_law_config               = 'threshold_thickness'            ! Choice of calving law: "none", "threshold_thickness"
-  REAL(dp)            :: calving_threshold_thickness_config      = 200._dp                          ! Threshold ice thickness in the "threshold_thickness" calving law (200m taken from ANICE)
-  LOGICAL             :: do_remove_shelves_config                = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
-  LOGICAL             :: remove_shelves_larger_than_PD_config    = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
-  LOGICAL             :: continental_shelf_calving_config        = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
-  REAL(dp)            :: continental_shelf_min_height_config     = -2000._dp                        ! Maximum depth of the continental shelf
+  CHARACTER(LEN=256)  :: choice_calving_law_config                   = 'threshold_thickness'            ! Choice of calving law: "none", "threshold_thickness"
+  REAL(dp)            :: calving_threshold_thickness_config          = 200._dp                          ! Threshold ice thickness in the "threshold_thickness" calving law (200m taken from ANICE)
+  LOGICAL             :: do_remove_shelves_config                    = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
+  LOGICAL             :: remove_shelves_larger_than_PD_config        = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
+  LOGICAL             :: continental_shelf_calving_config            = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
+  REAL(dp)            :: continental_shelf_min_height_config         = -2000._dp                        ! Maximum depth of the continental shelf
   
   ! Thermodynamics and rheology
   ! ===========================
@@ -445,7 +445,7 @@ MODULE configuration_module
   
   CHARACTER(LEN=256)  :: choice_BMB_shelf_model_config               = 'ANICE_legacy'                   ! Choice of shelf BMB: "uniform", "idealised", "ANICE_legacy", "Favier2019_lin", "Favier2019_quad", "Favier2019_Mplus", "Lazeroms2018_plume", "PICO", "PICOP"
   CHARACTER(LEN=256)  :: choice_idealised_BMB_shelf_config           = 'MISMIP+'
-  CHARACTER(LEN=256)  :: choice_BMB_sheet_model_config               = 'uniform'                        ! Choice of sheet BMB: "none"
+  CHARACTER(LEN=256)  :: choice_BMB_sheet_model_config               = 'uniform'                        ! Choice of sheet BMB: "uniform"
   REAL(dp)            :: BMB_shelf_uniform_config                    = 0._dp                            ! Uniform shelf BMB, applied when choice_BMB_shelf_model = "uniform" [mie/yr]
   REAL(dp)            :: BMB_sheet_uniform_config                    = 0._dp                            ! Uniform sheet BMB, applied when choice_BMB_sheet_model = "uniform" [mie/yr]
   CHARACTER(LEN=256)  :: choice_BMB_subgrid_config                   = 'FCMP'                           ! Choice of sub-grid BMB scheme: "FCMP", "PMP", "NMP" (following Leguy et al., 2021)
@@ -462,12 +462,13 @@ MODULE configuration_module
   LOGICAL             :: do_merge_basins_ANT_config                  = .TRUE.                           ! Whether or not to merge some of the Antarctic basins
   LOGICAL             :: do_merge_basins_GRL_config                  = .TRUE.                           ! Whether or not to merge some of the Greenland basins
  
-  INTEGER                  ::  basin_BMB_amplification_n_ANT_config         = 17                    ! Number of basins used for ANT
-  REAL(dp), DIMENSION(17)  ::  basin_BMB_amplification_factor_ANT_config    = &                     ! BMB amplification factor for each basin for ANT
+  CHARACTER(LEN=256)       ::  choice_BMB_shelf_amplification_config        = 'basin'                   ! Choice of method to determine BMB amplification factors: "uniform", "basin"
+  INTEGER                  ::  basin_BMB_amplification_n_ANT_config         = 17                        ! Number of basins used for ANT
+  REAL(dp), DIMENSION(17)  ::  basin_BMB_amplification_factor_ANT_config    = &                         ! BMB amplification factor for each basin for ANT
     (/ 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, &
        1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp /)
-  INTEGER                  ::  basin_BMB_amplification_n_GRL_config         = 8                     ! Number of basins used for GRL
-  REAL(dp), DIMENSION(8)   ::  basin_BMB_amplification_factor_GRL_config    = &                     ! BMB amplification factor for each basin for GRL 
+  INTEGER                  ::  basin_BMB_amplification_n_GRL_config         = 8                         ! Number of basins used for GRL
+  REAL(dp), DIMENSION(8)   ::  basin_BMB_amplification_factor_GRL_config    = &                         ! BMB amplification factor for each basin for GRL 
     (/ 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp, 1._dp /)
  
   ! Parameters for the three simple melt parameterisations from Favier et al. (2019)
@@ -1053,12 +1054,6 @@ MODULE configuration_module
     REAL(dp)                            :: BMB_sheet_uniform
     CHARACTER(LEN=256)                  :: choice_BMB_subgrid
     LOGICAL                             :: do_asynchronous_BMB
-    CHARACTER(LEN=256)                  :: choice_BMB_shelf_amplification
-    
-    INTEGER                             :: basin_BMB_amplification_n_ANT
-    REAL(dp), DIMENSION(:), ALLOCATABLE :: basin_BMB_amplification_factor_ANT
-    INTEGER                             :: basin_BMB_amplification_n_GRL
-    REAL(dp), DIMENSION(:), ALLOCATABLE :: basin_BMB_amplification_factor_GRL
     
     CHARACTER(LEN=256)                  :: choice_basin_scheme_NAM
     CHARACTER(LEN=256)                  :: choice_basin_scheme_EAS
@@ -1070,6 +1065,12 @@ MODULE configuration_module
     CHARACTER(LEN=256)                  :: filename_basins_ANT
     LOGICAL                             :: do_merge_basins_ANT
     LOGICAL                             :: do_merge_basins_GRL
+    
+    CHARACTER(LEN=256)                  :: choice_BMB_shelf_amplification
+    INTEGER                             :: basin_BMB_amplification_n_ANT
+    REAL(dp), DIMENSION(:), ALLOCATABLE :: basin_BMB_amplification_factor_ANT
+    INTEGER                             :: basin_BMB_amplification_n_GRL
+    REAL(dp), DIMENSION(:), ALLOCATABLE :: basin_BMB_amplification_factor_GRL
   
     ! Parameters for the three simple melt parameterisations from Favier et al. (2019)
     REAL(dp)                            :: BMB_Favier2019_lin_GammaT
@@ -1774,6 +1775,7 @@ CONTAINS
                      filename_basins_ANT_config,                      &
                      do_merge_basins_ANT_config,                      &
                      do_merge_basins_GRL_config,                      &
+                     choice_BMB_shelf_amplification_config,           &
                      basin_BMB_amplification_n_ANT_config,            &
                      basin_BMB_amplification_factor_ANT_config,       &
                      basin_BMB_amplification_n_GRL_config,            &
@@ -2351,12 +2353,13 @@ CONTAINS
     C%do_merge_basins_ANT                      = do_merge_basins_ANT_config
     C%do_merge_basins_GRL                      = do_merge_basins_GRL_config
     
-    C%basin_BMB_amplification_n_ANT       = basin_BMB_amplification_n_ANT_config
+    C%choice_BMB_shelf_amplification           = choice_BMB_shelf_amplification_config
+    C%basin_BMB_amplification_n_ANT            = basin_BMB_amplification_n_ANT_config
     ALLOCATE( C%basin_BMB_amplification_factor_ANT( C%basin_BMB_amplification_n_ANT))
-    C%basin_BMB_amplification_factor_ANT  = basin_BMB_amplification_factor_ANT_config( 1:C%basin_BMB_amplification_n_ANT)
-    C%basin_BMB_amplification_n_GRL       = basin_BMB_amplification_n_GRL_config
+    C%basin_BMB_amplification_factor_ANT       = basin_BMB_amplification_factor_ANT_config( 1:C%basin_BMB_amplification_n_ANT)
+    C%basin_BMB_amplification_n_GRL            = basin_BMB_amplification_n_GRL_config
     ALLOCATE( C%basin_BMB_amplification_factor_GRL( C%basin_BMB_amplification_n_GRL)) 
-    C%basin_BMB_amplification_factor_GRL  = basin_BMB_amplification_factor_GRL_config( 1:C%basin_BMB_amplification_n_GRL)
+    C%basin_BMB_amplification_factor_GRL       = basin_BMB_amplification_factor_GRL_config( 1:C%basin_BMB_amplification_n_GRL)
     
     ! Parameters for the three simple melt parameterisations from Favier et al. (2019)
     C%BMB_Favier2019_lin_GammaT                = BMB_Favier2019_lin_GammaT_config

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -125,17 +125,9 @@ MODULE data_types_module
     INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_sheet_a          ! Grounded ice
     INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_shelf_a          ! Floating ice
     INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_coast_a          ! On A-grid: land bordering ocean
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_coast_cx         ! On C-grid: in between A-land and A-ocean
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_coast_cy
     INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_margin_a         ! On A-grid: ice  bordering non-ice
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_margin_cx        ! On C-grid: in between A-ice and A-non-ice
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_margin_cy
     INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_gl_a             ! On A-grid: sheet bordering shelf
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_gl_cx            ! On C-grid: in between A-sheet and A-shelf
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_gl_cy
     INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_cf_a             ! On A-grid: shelf bordering ocean
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_cf_cx            ! On C-grid: in between A-shelf and A-ocean
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_cf_cy
     INTEGER,  DIMENSION(:,:  ), POINTER     :: mask_a                ! Multi-info mask, only used for writing to output
     REAL(dp), DIMENSION(:,:  ), POINTER     :: f_grnd_a              ! Grounded fraction (used to determine basal friction in DIVA)
     REAL(dp), DIMENSION(:,:  ), POINTER     :: f_grnd_cx
@@ -144,8 +136,7 @@ MODULE data_types_module
     INTEGER,  DIMENSION(:,:  ), POINTER     :: basin_ID              ! The drainage basin to which each grid cell belongs
     INTEGER,                    POINTER     :: nbasins               ! Total number of basins defined for this region
     INTEGER :: wmask_land_a, wmask_ocean_a, wmask_lake_a, wmask_ice_a, wmask_sheet_a, wmask_shelf_a
-    INTEGER :: wmask_coast_a, wmask_coast_cx, wmask_coast_cy, wmask_margin_a, wmask_margin_cx, wmask_margin_cy
-    INTEGER :: wmask_gl_a, wmask_gl_cx, wmask_gl_cy, wmask_cf_a, wmask_cf_cx, wmask_cf_cy, wmask_a
+    INTEGER :: wmask_coast_a, wmask_margin_a, wmask_gl_a, wmask_cf_a, wmask_a
     INTEGER :: wf_grnd_a, wf_grnd_cx, wf_grnd_cy, wf_grnd_b
     INTEGER :: wbasin_ID, wnbasins
     
@@ -255,8 +246,8 @@ MODULE data_types_module
     
     ! Ice dynamics - calving
     REAL(dp), DIMENSION(:,:  ), POINTER     :: float_margin_frac_a   ! Ice-covered fraction for calving front pixels
-    REAL(dp), DIMENSION(:,:  ), POINTER     :: Hi_actual_cf_a        ! "actual" ice thickness at calving front pixels (= Hi of thinnest non-calving-front neighbour)
-    INTEGER :: wfloat_margin_frac_a, wHi_actual_cf_a
+    REAL(dp), DIMENSION(:,:  ), POINTER     :: Hi_eff_cf_a           ! Effective ice thickness at calving front pixels (= Hi of thinnest non-calving-front neighbour)
+    INTEGER :: wfloat_margin_frac_a, wHi_eff_cf_a
     
     ! Ice dynamics - predictor/corrector ice thickness update
     REAL(dp),                   POINTER     :: pc_zeta

--- a/src/netcdf_module.f90
+++ b/src/netcdf_module.f90
@@ -433,27 +433,19 @@ CONTAINS
       
     ! Masks
     ELSEIF (field_name == 'mask') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_a,                     (/1, 1,    ti /))
+      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_a,         (/1, 1,    ti /))
     ELSEIF (field_name == 'mask_land') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_land_a,                (/1, 1,    ti /))
+      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_land_a,    (/1, 1,    ti /))
     ELSEIF (field_name == 'mask_ocean') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_ocean_a,               (/1, 1,    ti /))
+      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_ocean_a,   (/1, 1,    ti /))
     ELSEIF (field_name == 'mask_lake') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_lake_a,                (/1, 1,    ti /))
+      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_lake_a,    (/1, 1,    ti /))
     ELSEIF (field_name == 'mask_ice') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_ice_a,                 (/1, 1,    ti /))
+      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_ice_a,     (/1, 1,    ti /))
     ELSEIF (field_name == 'mask_sheet') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_sheet_a,               (/1, 1,    ti /))
+      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_sheet_a,   (/1, 1,    ti /))
     ELSEIF (field_name == 'mask_shelf') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_shelf_a,               (/1, 1,    ti /))
-    ELSEIF (field_name == 'mask_coast') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_coast_a,               (/1, 1,    ti /))
-    ELSEIF (field_name == 'mask_margin') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_margin_a,              (/1, 1,    ti /))
-    ELSEIF (field_name == 'mask_gl') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_gl_a,                  (/1, 1,    ti /))
-    ELSEIF (field_name == 'mask_cf') THEN
-      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_cf_a,                  (/1, 1,    ti /))
+      CALL write_data_to_file_int_2D( ncid, nx, ny,     id_var,               region%ice%mask_shelf_a,   (/1, 1,    ti /))
       
     ! Basal conditions
     ELSEIF (field_name == 'phi_fric') THEN
@@ -1177,14 +1169,6 @@ CONTAINS
       CALL create_int_var(    region%help_fields%ncid, 'mask_sheet',               [x, y,    t], id_var, long_name='sheet mask')
     ELSEIF (field_name == 'mask_shelf') THEN
       CALL create_int_var(    region%help_fields%ncid, 'mask_shelf',               [x, y,    t], id_var, long_name='shelf mask')
-    ELSEIF (field_name == 'mask_coast') THEN
-      CALL create_int_var(    region%help_fields%ncid, 'mask_coast',               [x, y,    t], id_var, long_name='coast mask')
-    ELSEIF (field_name == 'mask_margin') THEN
-      CALL create_int_var(    region%help_fields%ncid, 'mask_margin',              [x, y,    t], id_var, long_name='margin mask')
-    ELSEIF (field_name == 'mask_gl') THEN
-      CALL create_int_var(    region%help_fields%ncid, 'mask_gl',                  [x, y,    t], id_var, long_name='grounding-line mask')
-    ELSEIF (field_name == 'mask_cf') THEN
-      CALL create_int_var(    region%help_fields%ncid, 'mask_cf',                  [x, y,    t], id_var, long_name='calving-front mask')
       
     ! Basal conditions
     ELSEIF (field_name == 'phi_fric') THEN

--- a/testrun.csh
+++ b/testrun.csh
@@ -3,5 +3,6 @@
 ./compile_all.csh
 
 rm -rf results_2021*
+rm -rf MISMIP_mod_spinup_40km
 
-mpiexec -n 2 IMAU_ICE_program   config-files/config_ANT_thermo_240kyr_40km
+mpiexec -n 2 IMAU_ICE_program   config-files/config_MISMIP_mod_spinup_40km


### PR DESCRIPTION
Fixed the way threshold-thickness calving is implemented. Some short tests indicate the new implementation allows for both advancing and retreating calving fronts, and doesn't noticeably slow down the model.
The application of the no-ice mask, the no-ice-beyond-PD-extent, remove-all-shelves, and continental-shelf-calving options have been moved to the "apply_ice_thickness_BC" routine in the ice_thickness_module.

Minor fixes:
- Didn't fully resolve the merge conflict with the basin-dependent BMB factor earlier, fixed that now.
- Removed the staggered-grid masks, as they were not used anywhere.