### PR TITLE
Bypasses for the ocean matrix method, fix in calving module

### DIFF
--- a/src/ice_dynamics_module.f90
+++ b/src/ice_dynamics_module.f90
@@ -340,7 +340,16 @@ CONTAINS
     ! Apply calving law
     ! 
     ! NOTE: done twice, so that the calving front is also allowed to retreat
-    IF (.NOT. C%choice_calving_law == 'none') THEN
+    IF (C%choice_calving_law == 'none') THEN 
+      CALL determine_masks_ice(                grid, ice)
+      CALL determine_masks_transitions(        grid, ice)
+      CALL determine_floating_margin_fraction( grid, ice)
+      
+      ! Remove unconnected shelves    
+      CALL determine_masks_ice(                grid, ice)
+      CALL determine_masks_transitions(        grid, ice)
+      CALL remove_unconnected_shelves(         grid, ice)    
+    ELSE
       CALL determine_masks_ice(                grid, ice)
       CALL determine_masks_transitions(        grid, ice)
       CALL determine_floating_margin_fraction( grid, ice)
@@ -354,7 +363,7 @@ CONTAINS
       ! Remove unconnected shelves
       CALL determine_masks_ice(                grid, ice)
       CALL determine_masks_transitions(        grid, ice)
-      CALL remove_unconnected_shelves(         grid, ice)
+      CALL remove_unconnected_shelves(         grid, ice)      
     END IF
     
     CALL update_general_ice_model_data(      grid, ice)


### PR DESCRIPTION
This commits adds two bypasses to the ocean matrix:
1) When C%ocean_matrix_CO2vsice_<region> is set to 1, no
calculation of the ice interpolation weight is needed. In
this way, the ocean matrix can be used without using the
climate matrix.
2) When ocean_matrix%applied%nw_tot_history == 1, for in-
stance by setting C%ocean_w_tot_hist_averaging_window_config
= 0.0, no history is kept, and the whole ocean instanta-
neously adjusts to the new forcing at the surface:
w_tot_final (k,j,i) = w_tot (j,i).

When no calving method is used (C%choice_calving_law == 'none'),
unconnected shelves are now still removed.