### PR TITLE
Added prescribed retreat masks

### DIFF
--- a/src/IMAU_ICE_main_model.f90
+++ b/src/IMAU_ICE_main_model.f90
@@ -175,7 +175,7 @@ CONTAINS
       END IF
 
       ! Update ice geometry and advance region time
-      CALL update_ice_thickness( region%grid, region%ice, region%mask_noice, region%refgeo_PD, region%refgeo_GIAeq)
+      CALL update_ice_thickness( region%grid, region%ice, region%mask_noice, region%refgeo_init, region%refgeo_PD, region%refgeo_GIAeq, region%time)
       IF (par%master) region%time = region%time + region%dt
       CALL sync
       

--- a/src/calving_module.f90
+++ b/src/calving_module.f90
@@ -12,10 +12,12 @@ MODULE calving_module
                                              allocate_shared_int_3D, allocate_shared_dp_3D, &
                                              deallocate_shared, partition_list
   USE data_types_module,               ONLY: type_grid, type_ice_model, type_reference_geometry
-  USE netcdf_module,                   ONLY: debug, write_to_debug_file
+  USE data_types_netcdf_module,        ONLY: type_netcdf_prescribed_retreat_mask
+  USE netcdf_module,                   ONLY: debug, write_to_debug_file, inquire_prescribed_retreat_mask_file, &
+                                             read_prescribed_retreat_mask_file
   USE utilities_module,                ONLY: check_for_NaN_dp_1D,  check_for_NaN_dp_2D,  check_for_NaN_dp_3D, &
                                              check_for_NaN_int_1D, check_for_NaN_int_2D, check_for_NaN_int_3D, &
-                                             is_floating
+                                             is_floating, map_square_to_square_cons_2nd_order_2D, transpose_dp_2D
 
   IMPLICIT NONE
   
@@ -54,7 +56,7 @@ CONTAINS
   END SUBROUTINE apply_calving_law
   
 ! == Routines for different calving laws
-! ===================================
+! ======================================
 
   SUBROUTINE threshold_thickness_calving( grid, ice)
     ! A simple threshold thickness calving law
@@ -86,5 +88,140 @@ CONTAINS
     CALL finalise_routine( routine_name)
     
   END SUBROUTINE threshold_thickness_calving
+  
+! == Routines for applying a prescribed retreat mask
+! ==================================================
+  
+  SUBROUTINE apply_prescribed_retreat_mask( grid, ice, time, refgeo_init)
+    ! Apply a prescribed retreat mask (e.g. as in ISMIP6-Greenland or PROTECT-Greenland)
+
+    IMPLICIT NONE
+
+    ! Input variables:
+    TYPE(type_grid),                     INTENT(IN)    :: grid
+    TYPE(type_ice_model),                INTENT(INOUT) :: ice
+    REAL(dp),                            INTENT(IN)    :: time
+    TYPE(type_reference_geometry),       INTENT(IN)    :: refgeo_init
+    
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'apply_prescribed_retreat_mask'
+    INTEGER                                            :: i,j
+    REAL(dp)                                           :: wt0, wt1
+    
+    ! Add routine to path
+    CALL init_routine( routine_name)
+    
+    ! Check if the requested time is enveloped by the two timeframes;
+    ! if not, read the two relevant timeframes from the NetCDF file
+    IF (time < ice%ice_fraction_retreat_mask_t0 .OR. time > ice%ice_fraction_retreat_mask_t1) THEN
+      
+      ! Find and read the two global time frames
+      CALL sync
+      CALL update_prescribed_retreat_mask_timeframes( grid, ice, time)
+      
+    END IF ! IF (time < ice%ice_fraction_retreat_mask_t0 .OR. time > ice%ice_fraction_retreat_mask_t1) THEN
+
+    ! Interpolate the two timeframes in time
+    wt0 = MAX( 0._dp, MIN( 1._dp, (ice%ice_fraction_retreat_mask_t1 - time) / (ice%ice_fraction_retreat_mask_t1 - ice%ice_fraction_retreat_mask_t0) ))
+    wt1 = 1._dp - wt0
+    
+    DO i = grid%i1, grid%i2
+    DO j = 1, grid%ny
+    
+      ice%ice_fraction_retreat_mask( j,i) = (wt0 * ice%ice_fraction_retreat_mask0( j,i)) + &
+                                            (wt1 * ice%ice_fraction_retreat_mask1( j,i))
+                                                    
+    END DO
+    END DO
+    CALL sync
+    
+    ! Apply the retreat mask following the ISMIP protocol
+    DO i = grid%i1, grid%i2
+    DO j = 1, grid%ny
+      IF (ice%ice_fraction_retreat_mask( j,i) < 0.999_dp) THEN 
+        ice%Hi_a( j,i) = MIN( ice%Hi_a( j,i), refgeo_init%Hi( j,i) * ice%ice_fraction_retreat_mask( j,i))
+      END IF
+    END DO
+    END DO
+    CALL sync
+    
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+    
+  END SUBROUTINE apply_prescribed_retreat_mask
+  SUBROUTINE update_prescribed_retreat_mask_timeframes( grid, ice, time)
+    ! Update the two timeframes of the prescribed retreat mask
+
+    IMPLICIT NONE
+
+    ! Input variables:
+    TYPE(type_grid),                     INTENT(IN)    :: grid
+    TYPE(type_ice_model),                INTENT(INOUT) :: ice
+    REAL(dp),                            INTENT(IN)    :: time
+    
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'update_prescribed_retreat_mask_timeframes'
+    INTEGER                                            :: i,j
+    TYPE(type_netcdf_prescribed_retreat_mask)          :: netcdf
+    TYPE(type_grid)                                    :: grid_raw
+    REAL(dp), DIMENSION(:,:  ), POINTER                ::  ice_fraction_retreat_mask_raw0
+    REAL(dp), DIMENSION(:,:  ), POINTER                ::  ice_fraction_retreat_mask_raw1
+    INTEGER                                            :: wice_fraction_retreat_mask_raw0
+    INTEGER                                            :: wice_fraction_retreat_mask_raw1
+    
+    
+    ! Add routine to path
+    CALL init_routine( routine_name)
+    
+    ! Inquire into the NetCDF file
+    CALL allocate_shared_int_0D( grid_raw%nx, grid_raw%wnx)
+    CALL allocate_shared_int_0D( grid_raw%ny, grid_raw%wny)
+    CALL inquire_prescribed_retreat_mask_file( netcdf, grid_raw%nx, grid_raw%ny)
+    CALL sync
+    
+    ! Allocate memory, read data
+    CALL allocate_shared_dp_1D( grid_raw%nx,              grid_raw%x                    , grid_raw%wx                    )
+    CALL allocate_shared_dp_1D(              grid_raw%ny, grid_raw%y                    , grid_raw%wy                    )
+    CALL allocate_shared_dp_2D( grid_raw%nx, grid_raw%ny, ice_fraction_retreat_mask_raw0, wice_fraction_retreat_mask_raw0)
+    CALL allocate_shared_dp_2D( grid_raw%nx, grid_raw%ny, ice_fraction_retreat_mask_raw1, wice_fraction_retreat_mask_raw1)
+    CALL read_prescribed_retreat_mask_file( netcdf, grid_raw%x, grid_raw%y, time, ice_fraction_retreat_mask_raw0, ice_fraction_retreat_mask_raw1, &
+      ice%ice_fraction_retreat_mask_t0, ice%ice_fraction_retreat_mask_t1)
+    CALL sync
+    
+    ! Safety
+    CALL check_for_NaN_dp_2D( ice_fraction_retreat_mask_raw0, 'ice_fraction_retreat_mask_raw0')
+    CALL check_for_NaN_dp_2D( ice_fraction_retreat_mask_raw1, 'ice_fraction_retreat_mask_raw1')
+        
+    ! Since we want data represented as [j,i] internally, transpose the data we just read.
+    CALL transpose_dp_2D( ice_fraction_retreat_mask_raw0, wice_fraction_retreat_mask_raw0)
+    CALL transpose_dp_2D( ice_fraction_retreat_mask_raw1, wice_fraction_retreat_mask_raw1)
+    
+    ! Map (transposed) raw data to the model grid
+    CALL map_square_to_square_cons_2nd_order_2D( grid_raw%nx, grid_raw%ny, grid_raw%x, grid_raw%y, grid%nx, grid%ny, grid%x, grid%y, &
+      ice_fraction_retreat_mask_raw0, ice%ice_fraction_retreat_mask0)
+    CALL map_square_to_square_cons_2nd_order_2D( grid_raw%nx, grid_raw%ny, grid_raw%x, grid_raw%y, grid%nx, grid%ny, grid%x, grid%y, &
+      ice_fraction_retreat_mask_raw1, ice%ice_fraction_retreat_mask1)
+      
+    ! Limit ice fractions to [0,1]
+    DO i = grid%i1, grid%i2
+    DO j = 1, grid%ny
+      ice%ice_fraction_retreat_mask0( j,i) = MAX( 0._dp, MIN( 1._dp, ice%ice_fraction_retreat_mask0( j,i)))
+      ice%ice_fraction_retreat_mask1( j,i) = MAX( 0._dp, MIN( 1._dp, ice%ice_fraction_retreat_mask1( j,i)))
+    END DO
+    END DO
+    CALL sync
+    
+    ! Deallocate raw data
+    CALL deallocate_shared( grid_raw%wnx                   )
+    CALL deallocate_shared( grid_raw%wny                   )
+    CALL deallocate_shared( grid_raw%wx                    )
+    CALL deallocate_shared( grid_raw%wy                    )
+    CALL deallocate_shared( wice_fraction_retreat_mask_raw0)
+    CALL deallocate_shared( wice_fraction_retreat_mask_raw1)
+    
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+    
+  END SUBROUTINE update_prescribed_retreat_mask_timeframes
   
 END MODULE calving_module

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -333,6 +333,10 @@ MODULE configuration_module
   LOGICAL             :: fixed_shelf_geometry_config                 = .FALSE.                          ! Keep geometry of floating ice fixed
   LOGICAL             :: fixed_sheet_geometry_config                 = .FALSE.                          ! Keep geometry of grounded ice fixed
   LOGICAL             :: fixed_grounding_line_config                 = .FALSE.                          ! Keep ice thickness at the grounding line fixed
+  
+  ! Prescribed retreat mask
+  LOGICAL             :: do_apply_prescribed_retreat_mask_config     = .FALSE.                          ! Whether or not to apply an externally prescribed retreat mask
+  CHARACTER(LEN=256)  :: prescribed_retreat_mask_filename_config     = ''                               ! NetCDF file containing a prescribed retreat mask
 
   ! Ice dynamics - basal conditions and sliding
   ! ===========================================
@@ -1051,6 +1055,10 @@ MODULE configuration_module
     LOGICAL                             :: fixed_shelf_geometry
     LOGICAL                             :: fixed_sheet_geometry
     LOGICAL                             :: fixed_grounding_line
+  
+    ! Prescribed retreat mask
+    LOGICAL                             :: do_apply_prescribed_retreat_mask
+    CHARACTER(LEN=256)                  :: prescribed_retreat_mask_filename
 
     ! Ice dynamics - basal conditions and sliding
     ! ===========================================
@@ -1891,6 +1899,8 @@ CONTAINS
                      fixed_shelf_geometry_config,                     &
                      fixed_sheet_geometry_config,                     &
                      fixed_grounding_line_config,                     &
+                     do_apply_prescribed_retreat_mask_config,         &
+                     prescribed_retreat_mask_filename_config,         &
                      choice_sliding_law_config,                       &
                      choice_idealised_sliding_law_config,             &
                      slid_delta_v_config,                             &
@@ -2647,6 +2657,10 @@ CONTAINS
     C%fixed_shelf_geometry                     = fixed_shelf_geometry_config
     C%fixed_sheet_geometry                     = fixed_sheet_geometry_config
     C%fixed_grounding_line                     = fixed_grounding_line_config
+  
+    ! Prescribed retreat mask
+    C%do_apply_prescribed_retreat_mask         = do_apply_prescribed_retreat_mask_config
+    C%prescribed_retreat_mask_filename         = prescribed_retreat_mask_filename_config
 
     ! Ice dynamics - basal conditions and sliding
     ! ===========================================

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -259,6 +259,14 @@ MODULE data_types_module
     REAL(dp), DIMENSION(:,:  ), POINTER     :: Hi_eff_cf_a           ! Effective ice thickness at calving front pixels (= Hi of thinnest non-calving-front neighbour)
     INTEGER :: wfloat_margin_frac_a, wHi_eff_cf_a
     
+    ! Ice dynamics - prescribed retreat mask
+    REAL(dp),                   POINTER     :: ice_fraction_retreat_mask_t0  ! Time of first     prescribed retreat mask timeframe ( <= region%time)
+    REAL(dp),                   POINTER     :: ice_fraction_retreat_mask_t1  ! Time of second    prescribed retreat mask timeframe ( >= region%time)
+    REAL(dp), DIMENSION(:,:  ), POINTER     :: ice_fraction_retreat_mask0    !         First     prescribed retreat mask timeframe
+    REAL(dp), DIMENSION(:,:  ), POINTER     :: ice_fraction_retreat_mask1    !         Second    prescribed retreat mask timeframe
+    REAL(dp), DIMENSION(:,:  ), POINTER     :: ice_fraction_retreat_mask     ! Time-interpolated prescribed retreat mask
+    INTEGER :: wice_fraction_retreat_mask_t0, wice_fraction_retreat_mask_t1, wice_fraction_retreat_mask0, wice_fraction_retreat_mask1, wice_fraction_retreat_mask
+    
     ! Ice dynamics - predictor/corrector ice thickness update
     REAL(dp),                   POINTER     :: pc_zeta
     REAL(dp), DIMENSION(:,:  ), POINTER     :: pc_tau

--- a/src/data_types_netcdf_module.f90
+++ b/src/data_types_netcdf_module.f90
@@ -1105,13 +1105,51 @@ MODULE data_types_netcdf_module
     INTEGER :: id_var_dSTdz
     
     CHARACTER(LEN=256) :: name_var_SMB                   = 'SMB                  '
-    CHARACTER(LEN=256) :: name_var_ST                    = 'T2m                  '
+    CHARACTER(LEN=256) :: name_var_ST                    = 'ST                   '
     CHARACTER(LEN=256) :: name_var_aSMB                  = 'aSMB                 '
     CHARACTER(LEN=256) :: name_var_dSMBdz                = 'dSMBdz               '
     CHARACTER(LEN=256) :: name_var_aST                   = 'aST                  '
     CHARACTER(LEN=256) :: name_var_dSTdz                 = 'dSTdz                '
     
   END TYPE type_netcdf_ISMIP_style_forcing
+  
+  TYPE type_netcdf_prescribed_retreat_mask
+    ! NetCDF files containing a prescribed retreat mask
+    
+    CHARACTER(LEN=256) :: filename
+    
+    ! ID for NetCDF file:
+    INTEGER :: ncid
+    
+  ! Dimensions
+  ! ==========
+    
+    INTEGER :: id_dim_x
+    INTEGER :: id_dim_y
+    INTEGER :: id_dim_time
+    
+    CHARACTER(LEN=256) :: name_dim_x                     = 'x1                   '
+    CHARACTER(LEN=256) :: name_dim_y                     = 'y1                   '
+    CHARACTER(LEN=256) :: name_dim_time                  = 'time                 '
+    
+  ! Variables
+  ! =========
+    
+    ! Dimensions
+    INTEGER :: id_var_x
+    INTEGER :: id_var_y
+    INTEGER :: id_var_time
+    
+    CHARACTER(LEN=256) :: name_var_x                     = 'x1                   '
+    CHARACTER(LEN=256) :: name_var_y                     = 'y1                   '
+    CHARACTER(LEN=256) :: name_var_time                  = 'time                 '
+    
+    ! Field variables
+    INTEGER :: id_var_ice_fraction
+    
+    CHARACTER(LEN=256) :: name_var_ice_fraction          = 'ice_fraction_retreat_mask'
+    
+  END TYPE type_netcdf_prescribed_retreat_mask
   
 CONTAINS
 

--- a/src/netcdf_module.f90
+++ b/src/netcdf_module.f90
@@ -6124,9 +6124,9 @@ CONTAINS
     CALL inquire_dim( netcdf%ncid, netcdf%name_dim_y, ny, netcdf%id_dim_y)
     
     ! Inquire variable id's. Make sure that each variable has the correct dimensions:
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_x,   (/ netcdf%id_dim_x                  /), netcdf%id_var_x  )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_y,   (/                  netcdf%id_dim_y /), netcdf%id_var_y  )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_SMB, (/ netcdf%id_dim_x, netcdf%id_dim_y /), netcdf%id_var_SMB)
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_x,   (/ netcdf%id_dim_x                  /), netcdf%id_var_x  )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_y,   (/                  netcdf%id_dim_y /), netcdf%id_var_y  )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_SMB, (/ netcdf%id_dim_x, netcdf%id_dim_y /), netcdf%id_var_SMB)
     
     ! Close the netcdf file
     CALL close_netcdf_file( netcdf%ncid)
@@ -6197,9 +6197,9 @@ CONTAINS
     CALL inquire_dim( netcdf%ncid, netcdf%name_dim_y, ny, netcdf%id_dim_y)
     
     ! Inquire variable id's. Make sure that each variable has the correct dimensions:
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_x,   (/ netcdf%id_dim_x                  /), netcdf%id_var_x  )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_y,   (/                  netcdf%id_dim_y /), netcdf%id_var_y  )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_ST,  (/ netcdf%id_dim_x, netcdf%id_dim_y /), netcdf%id_var_ST)
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_x,   (/ netcdf%id_dim_x                  /), netcdf%id_var_x  )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_y,   (/                  netcdf%id_dim_y /), netcdf%id_var_y  )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_ST,  (/ netcdf%id_dim_x, netcdf%id_dim_y /), netcdf%id_var_ST)
     
     ! Close the netcdf file
     CALL close_netcdf_file( netcdf%ncid)
@@ -6272,9 +6272,9 @@ CONTAINS
     CALL inquire_dim( netcdf%ncid, netcdf%name_dim_time, nt, netcdf%id_dim_time)
     
     ! Inquire variable id's. Make sure that each variable has the correct dimensions:
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_x,    (/ netcdf%id_dim_x                                      /), netcdf%id_var_x   )
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_y,    (/                  netcdf%id_dim_y                     /), netcdf%id_var_y   )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_aSMB, (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_aSMB)
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_x,    (/ netcdf%id_dim_x                                      /), netcdf%id_var_x   )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_y,    (/                  netcdf%id_dim_y                     /), netcdf%id_var_y   )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_aSMB, (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_aSMB)
     
     ! Close the netcdf file
     CALL close_netcdf_file( netcdf%ncid)
@@ -6347,9 +6347,9 @@ CONTAINS
     CALL inquire_dim( netcdf%ncid, netcdf%name_dim_time, nt, netcdf%id_dim_time)
     
     ! Inquire variable id's. Make sure that each variable has the correct dimensions:
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_x,      (/ netcdf%id_dim_x                                      /), netcdf%id_var_x     )
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_y,      (/                  netcdf%id_dim_y                     /), netcdf%id_var_y     )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_dSMBdz, (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_dSMBdz)
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_x,      (/ netcdf%id_dim_x                                      /), netcdf%id_var_x     )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_y,      (/                  netcdf%id_dim_y                     /), netcdf%id_var_y     )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_dSMBdz, (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_dSMBdz)
     
     ! Close the netcdf file
     CALL close_netcdf_file( netcdf%ncid)
@@ -6422,9 +6422,9 @@ CONTAINS
     CALL inquire_dim( netcdf%ncid, netcdf%name_dim_time, nt, netcdf%id_dim_time)
     
     ! Inquire variable id's. Make sure that each variable has the correct dimensions:
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_x,    (/ netcdf%id_dim_x                                      /), netcdf%id_var_x   )
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_y,    (/                  netcdf%id_dim_y                     /), netcdf%id_var_y   )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_aST,  (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_aST )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_x,    (/ netcdf%id_dim_x                                      /), netcdf%id_var_x   )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_y,    (/                  netcdf%id_dim_y                     /), netcdf%id_var_y   )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_aST,  (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_aST )
     
     ! Close the netcdf file
     CALL close_netcdf_file( netcdf%ncid)
@@ -6497,9 +6497,9 @@ CONTAINS
     CALL inquire_dim( netcdf%ncid, netcdf%name_dim_time, nt, netcdf%id_dim_time)
     
     ! Inquire variable id's. Make sure that each variable has the correct dimensions:
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_x,     (/ netcdf%id_dim_x                                      /), netcdf%id_var_x    )
-    CALL inquire_single_var( netcdf%ncid, netcdf%name_var_y,     (/                  netcdf%id_dim_y                     /), netcdf%id_var_y    )
-    CALL inquire_double_var( netcdf%ncid, netcdf%name_var_dSTdz, (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_dSTdz)
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_x,     (/ netcdf%id_dim_x                                      /), netcdf%id_var_x    )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_y,     (/                  netcdf%id_dim_y                     /), netcdf%id_var_y    )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_dSTdz, (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_dSTdz)
     
     ! Close the netcdf file
     CALL close_netcdf_file( netcdf%ncid)
@@ -6544,6 +6544,124 @@ CONTAINS
     CALL finalise_routine( routine_name)
     
   END SUBROUTINE read_ISMIP_forcing_dSTdz_file
+  
+  ! Prescribed retreat mask
+  SUBROUTINE inquire_prescribed_retreat_mask_file( netcdf, nx, ny)
+    ! Check if the right dimensions and variables are present in the file.
+
+    ! In/output variables:
+    TYPE(type_netcdf_prescribed_retreat_mask), INTENT(INOUT) :: netcdf
+    INTEGER,                                   INTENT(OUT)   :: nx, ny 
+    
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                 :: routine_name = 'inquire_prescribed_retreat_mask_file'
+    INTEGER                                       :: nt
+    
+    ! Add routine to path
+    CALL init_routine( routine_name)
+    
+    IF (.NOT. par%master) THEN
+      CALL finalise_routine( routine_name)
+      RETURN
+    END IF
+        
+    ! Open the netcdf file
+    netcdf%filename = TRIM( C%prescribed_retreat_mask_filename)
+    CALL open_netcdf_file( netcdf%filename, netcdf%ncid)
+    
+    ! Inquire dimensions id's. Check that all required dimensions exist return their lengths.
+    CALL inquire_dim( netcdf%ncid, netcdf%name_dim_x   , nx, netcdf%id_dim_x   )
+    CALL inquire_dim( netcdf%ncid, netcdf%name_dim_y   , ny, netcdf%id_dim_y   )
+    CALL inquire_dim( netcdf%ncid, netcdf%name_dim_time, nt, netcdf%id_dim_time)
+    
+    ! Inquire variable id's. Make sure that each variable has the correct dimensions:
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_x           , (/ netcdf%id_dim_x                                      /), netcdf%id_var_x           )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_y           , (/                  netcdf%id_dim_y                     /), netcdf%id_var_y           )
+    CALL inquire_int_var(              netcdf%ncid, netcdf%name_var_time        , (/                                   netcdf%id_dim_time /), netcdf%id_var_time        )
+    CALL inquire_single_or_double_var( netcdf%ncid, netcdf%name_var_ice_fraction, (/ netcdf%id_dim_x, netcdf%id_dim_y, netcdf%id_dim_time /), netcdf%id_var_ice_fraction)
+    
+    ! Close the netcdf file
+    CALL close_netcdf_file( netcdf%ncid)
+    
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+    
+  END SUBROUTINE inquire_prescribed_retreat_mask_file
+  SUBROUTINE read_prescribed_retreat_mask_file( netcdf, x, y, time, ice_fraction_retreat_mask_raw0, ice_fraction_retreat_mask_raw1, &
+    ice_fraction_retreat_mask_t0, ice_fraction_retreat_mask_t1)
+    ! Read the two timeframes enveloping the model time from the file
+
+    ! In/output variables:
+    TYPE(type_netcdf_prescribed_retreat_mask), INTENT(INOUT) :: netcdf
+    REAL(dp), DIMENSION(:    ),                INTENT(OUT)   :: x, y
+    REAL(dp),                                  INTENT(IN)    :: time
+    REAL(dp), DIMENSION(:,:  ),                INTENT(OUT)   :: ice_fraction_retreat_mask_raw0
+    REAL(dp), DIMENSION(:,:  ),                INTENT(OUT)   :: ice_fraction_retreat_mask_raw1
+    REAL(dp),                                  INTENT(OUT)   :: ice_fraction_retreat_mask_t0
+    REAL(dp),                                  INTENT(OUT)   :: ice_fraction_retreat_mask_t1
+    
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                 :: routine_name = 'read_prescribed_retreat_mask_file'
+    INTEGER                                       :: nx, ny
+    INTEGER                                       :: ntimes_in_file
+    INTEGER , DIMENSION(:    ), ALLOCATABLE       ::  times_in_file_int
+    REAL(dp), DIMENSION(:    ), ALLOCATABLE       ::  times_in_file_dp
+    INTEGER                                       :: ti0, ti1
+    REAL(dp), DIMENSION(:,:,:), ALLOCATABLE       :: retreat_mask_timeframe_with_time_dimension
+    
+    ! Add routine to path
+    CALL init_routine( routine_name)
+    
+    IF (.NOT. par%master) THEN
+      CALL finalise_routine( routine_name)
+      RETURN
+    END IF
+        
+    ! Open the netcdf file
+    netcdf%filename = TRIM( C%prescribed_retreat_mask_filename)
+    CALL open_netcdf_file( netcdf%filename, netcdf%ncid)
+    
+    ! Read the grid data
+    CALL handle_error( nf90_get_var( netcdf%ncid, netcdf%id_var_x, x, start = (/ 1 /) ))
+    CALL handle_error( nf90_get_var( netcdf%ncid, netcdf%id_var_y, y, start = (/ 1 /) ))
+    
+    ! Read time from file
+    CALL inquire_dim( netcdf%ncid, netcdf%name_dim_x   , nx            , netcdf%id_dim_x   )
+    CALL inquire_dim( netcdf%ncid, netcdf%name_dim_y   , ny            , netcdf%id_dim_y   )
+    CALL inquire_dim( netcdf%ncid, netcdf%name_dim_time, ntimes_in_file, netcdf%id_dim_time)
+    ALLOCATE( times_in_file_int( ntimes_in_file))
+    ALLOCATE( times_in_file_dp(  ntimes_in_file))
+    CALL handle_error( nf90_get_var( netcdf%ncid, netcdf%id_var_time, times_in_file_int, start = (/ 1 /) ))
+    times_in_file_dp = REAL( times_in_file_int, dp)
+    
+    ! Determine which timeframes to read
+    ti0 = 1
+    DO WHILE (times_in_file_dp( ti0) <= time .AND. ti0 < ntimes_in_file-1)
+      ti0 = ti0 + 1
+    END DO
+    ti1 = ti0 + 1
+    
+    ice_fraction_retreat_mask_t0 = times_in_file_dp( ti0)
+    ice_fraction_retreat_mask_t1 = times_in_file_dp( ti1)
+    
+    DEALLOCATE( times_in_file_int)
+    DEALLOCATE( times_in_file_dp )
+    
+    ! Read timeframes
+    ALLOCATE( retreat_mask_timeframe_with_time_dimension( nx, ny, 1))
+    CALL handle_error( nf90_get_var( netcdf%ncid, netcdf%id_var_ice_fraction, retreat_mask_timeframe_with_time_dimension, start = (/ 1, 1, ti0 /), count = (/ nx, ny, 1 /) ))
+    ice_fraction_retreat_mask_raw0 = retreat_mask_timeframe_with_time_dimension( :,:,1)
+    CALL handle_error( nf90_get_var( netcdf%ncid, netcdf%id_var_ice_fraction, retreat_mask_timeframe_with_time_dimension, start = (/ 1, 1, ti1 /), count = (/ nx, ny, 1 /) ))
+    ice_fraction_retreat_mask_raw1 = retreat_mask_timeframe_with_time_dimension( :,:,1)
+    DEALLOCATE( retreat_mask_timeframe_with_time_dimension)
+    
+    ! Close the netcdf file
+    CALL close_netcdf_file( netcdf%ncid)
+    
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+    
+  END SUBROUTINE read_prescribed_retreat_mask_file
   
 ! Some general useful stuff
 ! =========================
@@ -6849,6 +6967,37 @@ CONTAINS
     END IF
     
   END SUBROUTINE inquire_double_var
+  SUBROUTINE inquire_single_or_double_var( ncid, var_name, id_dims, id_var)
+    ! Inquire the id of a variable and check that the dimensions of the variable match the dimensions given by the user and
+    ! that the variable is of type nf90_FLOAT or nf90_DOUBLE.
+    IMPLICIT NONE
+
+    ! Input variables:
+    INTEGER,                    INTENT(IN)    :: ncid
+    CHARACTER(LEN=*),           INTENT(IN)    :: var_name
+    INTEGER, DIMENSION(:),      INTENT(IN)    :: id_dims
+
+    ! Output variables:
+    INTEGER,                INTENT(OUT)   :: id_var
+
+    ! Local variables:
+    INTEGER                               :: xtype, ndims
+    INTEGER, DIMENSION(nf90_max_var_dims) :: actual_id_dims
+
+    CALL handle_error(nf90_inq_varid(ncid, var_name, id_var))
+    CALL handle_error(nf90_inquire_variable(ncid, id_var, xtype=xtype,ndims=ndims,dimids=actual_id_dims))
+    IF (xtype /= nf90_double .AND. xtype /= nf90_float) THEN
+      CALL crash('Actual type of variable "' // TRIM( var_name) // '" is neither nf90_float nor nf90_double!')
+    END IF
+    IF (ndims /= SIZE( id_dims)) THEN
+      CALL crash('Actual number of dimensions = {int_01} of variable "' // TRIM( var_name) // '" does not match required number of dimensions = {int_02}', &
+        int_01 = ndims, int_02 = SIZE( id_dims))
+    END IF
+    IF (ANY( actual_id_dims( 1:ndims) /= id_dims)) THEN
+      CALL crash('Actual dimensions of variable "' // TRIM( var_name) // '" does not match required dimensions!')
+    END IF
+
+  END SUBROUTINE inquire_single_or_double_var
   SUBROUTINE handle_error( stat, message)
     USE netcdf, ONLY: nf90_noerr, nf90_strerror
     IMPLICIT NONE


### PR DESCRIPTION
Added the option to read and apply a prescribed, time-dependent retreat mask, as used in e.g. the PROTECT and ISMIP future projections for Greenland.