### PR TITLE
Hotfix/netcdf transposed

### DIFF
--- a/src/basal_conditions_and_sliding_module.f90
+++ b/src/basal_conditions_and_sliding_module.f90
@@ -2339,52 +2339,51 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    CALL warning('Reading basal inversion target velocity field has not been thoroughly tested. Please check if the data is read correctly.')
+    call crash('This routines needs to be tested and fixed regarding NetCDF I/O')
 
-    ! Determine filename
-    IF     (C%choice_BIVgeo_method == 'CISM+' .OR. &
-            C%choice_BIVgeo_method == 'Berends2022') THEN
-      BIV_target%filename = C%BIVgeo_target_velocity_filename
-    ELSE
-      CALL crash('unknown choice_BIVgeo_method "' // TRIM(C%choice_BIVgeo_method) // '"!')
-    END IF
+    ! ! Determine filename
+    ! IF     (C%choice_BIVgeo_method == 'CISM+' .OR. &
+    !         C%choice_BIVgeo_method == 'Berends2022') THEN
+    !   BIV_target%filename = C%BIVgeo_target_velocity_filename
+    ! ELSE
+    !   CALL crash('unknown choice_BIVgeo_method "' // TRIM(C%choice_BIVgeo_method) // '"!')
+    ! END IF
 
-    IF (par%master) WRITE(0,*) '  Initialising basal inversion target velocity from file ', TRIM( BIV_target%filename), '...'
+    ! IF (par%master) WRITE(0,*) '  Initialising basal inversion target velocity from file ', TRIM( BIV_target%filename), '...'
 
-    ! Read input field
-    CALL read_BIV_target_velocity( BIV_target, region_name)
-    CALL sync
+    ! ! Read input field
+    ! CALL read_BIV_target_velocity( BIV_target, region_name)
+    ! CALL sync
 
-    ! NOTE: do not check for NaNs in the target velocity field. The Rignot 2011 Antarctica velocity product
-    !       has a lot of missing data points, indicated by NaN values. This is acceptable, the basal inversion
-    !       routine can handle that.
+    ! ! NOTE: do not check for NaNs in the target velocity field. The Rignot 2011 Antarctica velocity product
+    ! !       has a lot of missing data points, indicated by NaN values. This is acceptable, the basal inversion
+    ! !       routine can handle that.
 
-    ! CALL check_for_NaN_dp_2D( BIV_target%u_surf, 'BIV_target%u_surf')
-    ! CALL check_for_NaN_dp_2D( BIV_target%v_surf, 'BIV_target%v_surf')
+    ! ! CALL check_for_NaN_dp_2D( BIV_target%u_surf, 'BIV_target%u_surf')
+    ! ! CALL check_for_NaN_dp_2D( BIV_target%v_surf, 'BIV_target%v_surf')
 
-    CALL allocate_shared_dp_2D( BIV_target%grid%ny, BIV_target%grid%nx, BIV_target%uabs_surf, BIV_target%wuabs_surf)
+    ! CALL allocate_shared_dp_2D( BIV_target%grid%ny, BIV_target%grid%nx, BIV_target%uabs_surf, BIV_target%wuabs_surf)
 
-    ! Get absolute velocity
-    CALL partition_list( BIV_target%grid%nx, par%i, par%n, i1, i2)
-    DO i = i1, i2
-    DO j = 1, BIV_target%grid%ny
-      BIV_target%uabs_surf( i,j) = SQRT( BIV_target%u_surf( i,j)**2 + BIV_target%v_surf( i,j)**2)
-    END DO
-    END DO
-    CALL sync
+    ! ! Get absolute velocity
+    ! CALL partition_list( BIV_target%grid%nx, par%i, par%n, i1, i2)
+    ! DO i = i1, i2
+    ! DO j = 1, BIV_target%grid%ny
+    !   BIV_target%uabs_surf( i,j) = SQRT( BIV_target%u_surf( i,j)**2 + BIV_target%v_surf( i,j)**2)
+    ! END DO
+    ! END DO
+    ! CALL sync
 
-    ! Allocate shared memory
-    CALL allocate_shared_dp_2D( grid%ny, grid%nx, ice%BIV_uabs_surf_target, ice%wBIV_uabs_surf_target)
+    ! ! Allocate shared memory
+    ! CALL allocate_shared_dp_2D( grid%ny, grid%nx, ice%BIV_uabs_surf_target, ice%wBIV_uabs_surf_target)
 
-    ! Map (transposed) raw data to the model grid
-    CALL map_square_to_square_cons_2nd_order_2D( BIV_target%grid%nx, BIV_target%grid%ny, BIV_target%grid%x, BIV_target%grid%y, grid%nx, grid%ny, grid%x, grid%y, BIV_target%uabs_surf, ice%BIV_uabs_surf_target)
+    ! ! Map (transposed) raw data to the model grid
+    ! CALL map_square_to_square_cons_2nd_order_2D( BIV_target%grid%nx, BIV_target%grid%ny, BIV_target%grid%x, BIV_target%grid%y, grid%nx, grid%ny, grid%x, grid%y, BIV_target%uabs_surf, ice%BIV_uabs_surf_target)
 
-
-    ! Deallocate raw data
-    CALL deallocate_grid(   BIV_target%grid      )
-    CALL deallocate_shared( BIV_target%wu_surf   )
-    CALL deallocate_shared( BIV_target%wv_surf   )
-    CALL deallocate_shared( BIV_target%wuabs_surf)
+    ! ! Deallocate raw data
+    ! CALL deallocate_grid(   BIV_target%grid      )
+    ! CALL deallocate_shared( BIV_target%wu_surf   )
+    ! CALL deallocate_shared( BIV_target%wv_surf   )
+    ! CALL deallocate_shared( BIV_target%wuabs_surf)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)
@@ -2474,58 +2473,60 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    IF (.NOT. par%master) THEN
-      CALL finalise_routine( routine_name)
-      RETURN
-    END IF
+    call crash('This routines needs to be tested and fixed regarding NetCDF I/O')
 
-    CALL read_field_from_xy_file_2D(           BIV_target%filename, 'u_surf', region_name, BIV_target%grid, BIV_target%u_surf,BIV_target%wu_surf)
-    CALL read_field_from_xy_file_2D(           BIV_target%filename, 'v_surf', region_name, BIV_target%grid, BIV_target%v_surf,BIV_target%wv_surf)
+    ! IF (.NOT. par%master) THEN
+    !   CALL finalise_routine( routine_name)
+    !   RETURN
+    ! END IF
 
-    ! Exception: for some reason, the Rignot 2011 data has the y-axis reversed...
-    is_Rignot2011 = .FALSE.
-    DO i = 1, 256-36
-      IF (BIV_target%filename(i:i+33) == 'antarctica_ice_velocity_450m_v2.nc') THEN
-        is_Rignot2011 = .TRUE.
-      END IF
-    END DO
-    IF (is_Rignot2011) THEN
+    ! CALL read_field_from_xy_file_2D(           BIV_target%filename, 'u_surf', region_name, BIV_target%grid, BIV_target%u_surf,BIV_target%wu_surf)
+    ! CALL read_field_from_xy_file_2D(           BIV_target%filename, 'v_surf', region_name, BIV_target%grid, BIV_target%v_surf,BIV_target%wv_surf)
 
-      ! Allocate temporary memory for storing the upside-down data
-      ALLOCATE( y_temp( BIV_target%grid%ny))
-      ALLOCATE( u_temp( BIV_target%grid%nx, BIV_target%grid%ny))
-      ALLOCATE( v_temp( BIV_target%grid%nx, BIV_target%grid%ny))
+    ! ! Exception: for some reason, the Rignot 2011 data has the y-axis reversed...
+    ! is_Rignot2011 = .FALSE.
+    ! DO i = 1, 256-36
+    !   IF (BIV_target%filename(i:i+33) == 'antarctica_ice_velocity_450m_v2.nc') THEN
+    !     is_Rignot2011 = .TRUE.
+    !   END IF
+    ! END DO
+    ! IF (is_Rignot2011) THEN
 
-      ! Copy the upside-down data to temporary memory
-      y_temp = BIV_target%grid%y
-      u_temp = BIV_target%u_surf
-      v_temp = BIV_target%v_surf
+    !   ! Allocate temporary memory for storing the upside-down data
+    !   ALLOCATE( y_temp( BIV_target%grid%ny))
+    !   ALLOCATE( u_temp( BIV_target%grid%nx, BIV_target%grid%ny))
+    !   ALLOCATE( v_temp( BIV_target%grid%nx, BIV_target%grid%ny))
 
-      ! Flip the data
-      DO j = 1, BIV_target%grid%ny
-        BIV_target%grid%y(   j) = y_temp(   BIV_target%grid%ny + 1 - j)
-        BIV_target%u_surf( :,j) = u_temp( :,BIV_target%grid%ny + 1 - j)
-        BIV_target%v_surf( :,j) = v_temp( :,BIV_target%grid%ny + 1 - j)
-      END DO
+    !   ! Copy the upside-down data to temporary memory
+    !   y_temp = BIV_target%grid%y
+    !   u_temp = BIV_target%u_surf
+    !   v_temp = BIV_target%v_surf
 
-      ! Deallocate temporary memory
-      DEALLOCATE( y_temp)
-      DEALLOCATE( u_temp)
-      DEALLOCATE( v_temp)
+    !   ! Flip the data
+    !   DO j = 1, BIV_target%grid%ny
+    !     BIV_target%grid%y(   j) = y_temp(   BIV_target%grid%ny + 1 - j)
+    !     BIV_target%u_surf( :,j) = u_temp( :,BIV_target%grid%ny + 1 - j)
+    !     BIV_target%v_surf( :,j) = v_temp( :,BIV_target%grid%ny + 1 - j)
+    !   END DO
 
-      ! Set missing values to NaN
-      NaN = 0._dp
-      NaN = 0._dp / NaN
-      DO i = 1, BIV_target%grid%nx
-      DO j = 1, BIV_target%grid%ny
-        IF (BIV_target%u_surf( i,j) == 0._dp .AND. BIV_target%v_surf( i,j) == 0._dp) THEN
-          BIV_target%u_surf( i,j) = NaN
-          BIV_target%v_surf( i,j) = NaN
-        END IF
-      END DO
-      END DO
+    !   ! Deallocate temporary memory
+    !   DEALLOCATE( y_temp)
+    !   DEALLOCATE( u_temp)
+    !   DEALLOCATE( v_temp)
 
-    END IF ! IF (is_Rignot2011) THEN
+    !   ! Set missing values to NaN
+    !   NaN = 0._dp
+    !   NaN = 0._dp / NaN
+    !   DO i = 1, BIV_target%grid%nx
+    !   DO j = 1, BIV_target%grid%ny
+    !     IF (BIV_target%u_surf( i,j) == 0._dp .AND. BIV_target%v_surf( i,j) == 0._dp) THEN
+    !       BIV_target%u_surf( i,j) = NaN
+    !       BIV_target%v_surf( i,j) = NaN
+    !     END IF
+    !   END DO
+    !   END DO
+
+    ! END IF ! IF (is_Rignot2011) THEN
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -14,11 +14,10 @@ MODULE data_types_module
     ! A regular square grid
 
     INTEGER,                    POINTER     :: nx, ny, n
-    REAL(dp),                   POINTER     :: dx, tol_dist
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: ij2n, n2ij
+    REAL(dp),                   POINTER     :: dx
     REAL(dp), DIMENSION(:    ), POINTER     :: x, y
     REAL(dp),                   POINTER     :: xmin, xmax, ymin, ymax
-    INTEGER :: wnx, wny, wn, wdx, wtol_dist, wij2n, wn2ij, wx, wy, wxmin, wxmax, wymin, wymax
+    INTEGER :: wnx, wny, wn, wdx, wx, wy, wxmin, wxmax, wymin, wymax
     INTEGER                                 :: i1, i2, j1, j2 ! Parallelisation by domain decomposition
 
     REAL(dp),                   POINTER     :: lambda_M

--- a/src/ice_thickness_module.f90
+++ b/src/ice_thickness_module.f90
@@ -1130,6 +1130,8 @@ CONTAINS
     ! Read data from file
     CALL read_field_from_file_2D( C%target_dhdt_filename, 'dHdt', grid, ice%dHi_dt_target, region_name)
 
+    CALL check_for_NaN_dp_2D( ice%dHi_dt_target, 'ice%dHi_dt_target')
+
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 

--- a/src/netcdf_input_module.f90
+++ b/src/netcdf_input_module.f90
@@ -1595,9 +1595,6 @@ CONTAINS
     CALL allocate_shared_dp_0D(                    grid%ymin       , grid%wymin       )
     CALL allocate_shared_dp_0D(                    grid%ymax       , grid%wymax       )
     CALL allocate_shared_dp_0D(                    grid%dx         , grid%wdx         )
-    CALL allocate_shared_dp_0D(                    grid%tol_dist   , grid%wtol_dist   )
-    CALL allocate_shared_int_2D( grid%nx, grid%ny, grid%ij2n       , grid%wij2n       )
-    CALL allocate_shared_int_2D( grid%n , 2,       grid%n2ij       , grid%wn2ij       )
     CALL allocate_shared_dp_0D(                    grid%lambda_m   , grid%wlambda_m   )
     CALL allocate_shared_dp_0D(                    grid%phi_m      , grid%wphi_m      )
     CALL allocate_shared_dp_0D(                    grid%beta_stereo, grid%wbeta_stereo)
@@ -1623,27 +1620,6 @@ CONTAINS
       grid%xmax = MAXVAL( grid%x)
       grid%ymin = MINVAL( grid%y)
       grid%ymax = MAXVAL( grid%y)
-
-      ! Tolerance; points lying within this distance of each other are treated as identical
-      grid%tol_dist = ((grid%xmax - grid%xmin) + (grid%ymax - grid%ymin)) * tol / 2._dp
-
-      ! Conversion tables for grid-form vs. vector-form data
-      n = 0
-      DO i = 1, grid%nx
-        IF (MOD(i,2) == 1) THEN
-          DO j = 1, grid%ny
-            n = n+1
-            grid%ij2n( i,j) = n
-            grid%n2ij( n,:) = [i,j]
-          END DO
-        ELSE
-          DO j = grid%ny, 1, -1
-            n = n+1
-            grid%ij2n( i,j) = n
-            grid%n2ij( n,:) = [i,j]
-          END DO
-        END IF
-      END DO
 
     END IF ! IF (par%master) THEN
     CALL sync
@@ -1680,7 +1656,7 @@ CONTAINS
     CALL sync
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name, 18)
+    CALL finalise_routine( routine_name, 15)
 
   END SUBROUTINE setup_xy_grid_from_file
 

--- a/src/netcdf_input_module.f90
+++ b/src/netcdf_input_module.f90
@@ -638,6 +638,8 @@ CONTAINS
 
     ! Transpose the input data
     CALL transpose_dp_2D( d, wd)
+    CALL transpose_dp_2D( grid%lon, grid%wlon)
+    CALL transpose_dp_2D( grid%lat, grid%wlat)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name, 19)
@@ -763,6 +765,8 @@ CONTAINS
 
     ! Transpose the input data
     CALL transpose_dp_3D( d, wd )
+    CALL transpose_dp_2D( grid%lon, grid%wlon)
+    CALL transpose_dp_2D( grid%lat, grid%wlat)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name, 19)
@@ -902,6 +906,8 @@ CONTAINS
 
     ! Transpose the input data
     CALL transpose_dp_3D( d, wd )
+    CALL transpose_dp_2D( grid%lon, grid%wlon)
+    CALL transpose_dp_2D( grid%lat, grid%wlat)
 
     ! Clean up after yourself
     CALL deallocate_shared(   wzeta_from_file)
@@ -1473,7 +1479,7 @@ CONTAINS
     INTEGER                                            :: wntime_history, wtime_history,wd_with_time
     INTEGER                                            :: ti
 
-    
+
     ! Add routine to path
     CALL init_routine( routine_name)
 
@@ -1512,16 +1518,16 @@ CONTAINS
       CALL find_timeframe( filename, time_to_read, ti)
       ! Read data
       CALL read_var_dp_2D( filename, id_var, d_with_time, start = (/ 1, ti /), count = (/ ntime_history, 1 /) )
-      
+
       ! Copy to output memory
-      IF (par%master) THEN  
+      IF (par%master) THEN
          d( :) = d_with_time( :,1)
-      END IF 
+      END IF
       CALL sync
 
       ! Clean up after yourself
       CALL deallocate_shared( wd_with_time)
-      
+
    END IF
 
    CALL deallocate_shared( wntime_history)
@@ -1531,7 +1537,7 @@ CONTAINS
    CALL finalise_routine( routine_name, 19)
 
    END SUBROUTINE read_field_from_file_history_1D
- 
+
   ! ===== Set up grids from a NetCDF file =====
   ! ================================================
 

--- a/src/netcdf_output_module.f90
+++ b/src/netcdf_output_module.f90
@@ -418,13 +418,13 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    ! Variable name for the time_history dimension 
+    ! Variable name for the time_history dimension
     var_name_time_history = 'time_' // TRIM( var_name)
 
     CALL allocate_shared_dp_1D(      ntime_history, time_history, wtime_history )
 
     DO i = 1,ntime_history
-        time_history( i) = -i * C%dt_coupling 
+        time_history( i) = -i * C%dt_coupling
     END DO
 
     ! Add the time_history to file
@@ -454,7 +454,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE add_field_history_dp_1D
-  
+
   SUBROUTINE create_restart_file_grid( filename, grid)
     ! Create an empty restart file with the specified grid
 
@@ -480,11 +480,11 @@ CONTAINS
     CALL add_time_dimension_to_file(  filename)
     CALL add_zeta_dimension_to_file(  filename)
     CALL add_month_dimension_to_file( filename)
-    
+
     ! Add a time_history dimension for the inverse 18O simulation
     !IF (C%choice_forcing_method == 'd18O_inverse_CO2' .OR. &
     !   (C%choice_forcing_method == 'd18O_inverse_dT_glob')) THEN
-    !    CALL add_time_history_dimension_to_file(  filename)    
+    !    CALL add_time_history_dimension_to_file(  filename)
     !END IF
 
     ! Create variables
@@ -1011,19 +1011,19 @@ CONTAINS
     ELSE
       CALL crash('unknown choice_ice_isotopes_model "' // TRIM(C%choice_ice_isotopes_model) // '"!')
     END IF
-    
+
     ! Inverse routine data
     IF (C%choice_forcing_method == 'd18O_inverse_CO2') THEN
       IF (.NOT.(PRESENT( forcing))) CALL crash('write_to_restart_file_grid needs forcing field if d18O_inverse_CO2 is used')
       CALL write_to_field_history_dp_1D( filename, forcing%nCO2_inverse_history, 'CO2_inverse_history',  forcing%CO2_inverse_history)
       CALL write_to_field_history_dp_1D( filename, forcing%ndT_glob_history,     'dT_glob_history',      forcing%dT_glob_history)
     END IF
-    
+
     IF (C%choice_forcing_method == 'd18O_inverse_dT_glob') THEN
-      IF (.NOT.(PRESENT( forcing))) CALL crash('write_to_restart_file_grid needs forcing field if d18O_inverse_dT_glob is used')    
+      IF (.NOT.(PRESENT( forcing))) CALL crash('write_to_restart_file_grid needs forcing field if d18O_inverse_dT_glob is used')
       CALL write_to_field_history_dp_1D( filename, forcing%ndT_glob_inverse_history, 'dT_glob_inverse_history' , forcing%dT_glob_inverse_history)
     END IF
-    
+
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 
@@ -2183,12 +2183,12 @@ CONTAINS
     CALL permute_2D_dp( d_grid, wd_grid, map = [2,1])
     CALL write_var_dp_2D( filename, id_var_lon, d_grid)
     CALL deallocate_shared(wd_grid)
-    
+
     ! lat
     CALL add_field_grid_dp_2D_notime( filename, get_first_option_from_list( field_name_options_lat), long_name = 'Latitude', units = 'degrees north')
     CALL inquire_var_multiple_options( filename, field_name_options_lat, id_var_lat)
     CALL allocate_shared_dp_2D( grid%ny, grid%nx, d_grid, wd_grid)
-    d_grid( :, grid%i1:grid%i2) = grid%lon( :,grid%i1:grid%i2)
+    d_grid( :, grid%i1:grid%i2) = grid%lat( :,grid%i1:grid%i2)
     CALL sync
     CALL permute_2D_dp( d_grid, wd_grid, map = [2,1])
     CALL write_var_dp_2D( filename, id_var_lat, d_grid)
@@ -2683,7 +2683,7 @@ CONTAINS
     INTEGER                                            :: ntime_history
 
     ! Number of time history
-    ntime_history = SIZE(time_history,1) 
+    ntime_history = SIZE(time_history,1)
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -2703,7 +2703,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE add_time_history_dimension_to_file
-  
+
   SUBROUTINE add_month_dimension_to_file( filename)
     ! Add a month dimension and variable to an existing NetCDF file
 

--- a/src/ocean_module.f90
+++ b/src/ocean_module.f90
@@ -1790,10 +1790,6 @@ CONTAINS
     CALL map_glob_to_grid_3D( ocean_glob%grid%nlat, ocean_glob%grid%nlon, ocean_glob%grid%lat, ocean_glob%grid%lon, hires%grid, ocean_glob%T_ocean, hires%T_ocean)
     CALL map_glob_to_grid_3D( ocean_glob%grid%nlat, ocean_glob%grid%nlon, ocean_glob%grid%lat, ocean_glob%grid%lon, hires%grid, ocean_glob%S_ocean, hires%S_ocean)
 
-    ! Permute the i and j dimensions to account for some weird orientation issue during mapping
-    CALL permute_3D_dp( hires%T_ocean, hires%wT_ocean, map = [1,3,2])
-    CALL permute_3D_dp( hires%S_ocean, hires%wS_ocean, map = [1,3,2])
-
     ! ===== Perform the extrapolation on the high-resolution grid =====
     ! =================================================================
 

--- a/src/utilities_module.f90
+++ b/src/utilities_module.f90
@@ -1983,7 +1983,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE transpose_dp_3D
-  
+
   SUBROUTINE transpose_int_2D( d, wd)
     ! Transpose a data field (i.e. go from [i,j] to [j,i] indexing or the other way round)
 
@@ -3183,7 +3183,7 @@ CONTAINS
     ! Clean up after yourself
     CALL deallocate_shared( grid%wnx         )
     CALL deallocate_shared( grid%wny         )
-	CALL deallocate_shared( grid%wn          )
+	  CALL deallocate_shared( grid%wn          )
     CALL deallocate_shared( grid%wx          )
     CALL deallocate_shared( grid%wy          )
     CALL deallocate_shared( grid%wdx         )
@@ -3191,9 +3191,6 @@ CONTAINS
     CALL deallocate_shared( grid%wxmax       )
     CALL deallocate_shared( grid%wymin       )
     CALL deallocate_shared( grid%wymax       )
-    CALL deallocate_shared( grid%wtol_dist   )
-    CALL deallocate_shared( grid%wij2n       )
-    CALL deallocate_shared( grid%wn2ij       )
     CALL deallocate_shared( grid%wlambda_m   )
     CALL deallocate_shared( grid%wphi_m      )
     CALL deallocate_shared( grid%wbeta_stereo)


### PR DESCRIPTION
Missing transposition of lat/lon fields when setting up a grid from a NetCDF file. Mostly affected the extrapolation of ocean data read from external files. Small bug-fixes (detailed in the commit messages), plus removal of a couple of unused variables.