### PR TITLE
Origin/project/mpt

### DIFF
--- a/src/IMAU_ICE_main_model.f90
+++ b/src/IMAU_ICE_main_model.f90
@@ -221,7 +221,11 @@ CONTAINS
 
       ! Write scalar output
       CALL calculate_icesheet_volume_and_area(region)
-      CALL write_regional_scalar_data( region, region%time)
+
+      IF (C%do_write_regional_scalar_every_timestep) THEN
+        ! Save regional scalar every model time-step
+        CALL write_regional_scalar_data( region, region%time)
+      END IF
 
       ! Update ice geometry and advance region time
       CALL update_ice_thickness( region%grid, region%ice, region%mask_noice, region%refgeo_PD, region%refgeo_GIAeq, region%time)
@@ -256,6 +260,9 @@ CONTAINS
     ! Determine total ice sheet area, volume, volume-above-flotation and GMSL contribution,
     ! used for writing to text output and in the inverse routine
     CALL calculate_icesheet_volume_and_area(region)
+
+    ! Keep track of the GMSL contribution
+    IF (par%master) WRITE(0,'(A,A3,A,F9.3,A)') '  - ',TRIM( region%name), ' GMSL contribution:', region%GMSL_contribution, ' m' 
 
     ! Write to text output
     CALL write_regional_scalar_data( region, region%time)

--- a/src/IMAU_ICE_program.f90
+++ b/src/IMAU_ICE_program.f90
@@ -26,7 +26,7 @@ PROGRAM IMAU_ICE_program
                                              type_global_scalar_data, type_netcdf_resource_tracker
   USE petsc_module,                    ONLY: initialise_petsc, finalise_petsc
   USE forcing_module,                  ONLY: forcing, initialise_global_forcing, update_global_forcing, &
-                                             update_global_mean_temperature_change_history, &
+                                             update_global_mean_temperature_change_history, update_d18O_at_model_time, &
                                              calculate_modelled_d18O, inverse_routine_global_temperature_offset, &
                                              inverse_routine_CO2, update_sealevel_record_at_model_time
   USE ocean_module,                    ONLY: initialise_ocean_model_global, initialise_ocean_vertical_grid
@@ -283,6 +283,7 @@ PROGRAM IMAU_ICE_program
     IF     (C%choice_forcing_method == 'd18O_inverse_dT_glob') THEN
       CALL inverse_routine_global_temperature_offset
     ELSEIF (C%choice_forcing_method == 'd18O_inverse_CO2') THEN
+      CALL update_d18O_at_model_time( t_coupling)
       CALL inverse_routine_CO2
     ELSEIF (C%choice_forcing_method == 'CO2_direct' .OR. C%choice_forcing_method == 'none') THEN
       ! No inverse routine is used in these forcing methods

--- a/src/SMB_module.f90
+++ b/src/SMB_module.f90
@@ -383,11 +383,12 @@ CONTAINS
         ! Determine accumulation with snow/rain fraction from Ohmura et al. (1999),
         ! liquid water content (rain and melt water) and snowdepth
 
-        ! NOTE: commented version is the old ANICE version, supposedly based on "physics" (which we cant check), but
-        !       the new version was tuned to RACMO output and produced significantly better snow fractions...
-
-        ! snowfrac = MAX(0._dp, MIN(1._dp, 0.5_dp   * (1 - ATAN((climate%T2m(vi,m) - T0) / 3.5_dp)  / 1.25664_dp)))
-        snowfrac = MAX(0._dp, MIN(1._dp, 0.725_dp * (1 - ATAN((climate%T2m( m,j,i) - T0) / 5.95_dp) / 1.8566_dp)))
+        ! NOTE: The old ANICE version is supposedly based on "physics" (which we cant check, but
+        ! there is no snowfall when temperatures are well above the freezing point)
+        ! The new version was tuned to RACMO output and produced significantly better Greenland snow fractions...
+        ! However there is still snowfall even if temperatures are at 300 K, which does not seem realistic.
+        snowfrac = MAX(0._dp, MIN(1._dp, 0.5_dp   * (1 - ATAN((climate%T2m( m,j,i) - T0) / 3.5_dp)  / 1.25664_dp)))  ! Old ANICE "realistic" snow fractions
+        ! snowfrac = MAX(0._dp, MIN(1._dp, 0.725_dp * (1 - ATAN((climate%T2m( m,j,i) - T0) / 5.95_dp) / 1.8566_dp))) ! IMAU-ICE "tuned" snow fractions
 
         SMB%Snowfall( m,j,i) = climate%Precip( m,j,i) *          snowfrac
         SMB%Rainfall( m,j,i) = climate%Precip( m,j,i) * (1._dp - snowfrac)

--- a/src/basal_conditions_and_sliding_module.f90
+++ b/src/basal_conditions_and_sliding_module.f90
@@ -2339,52 +2339,51 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    CALL warning('Reading basal inversion target velocity field has not been thoroughly tested. Please check if the data is read correctly.')
+    call crash('This routines needs to be tested and fixed regarding NetCDF I/O')
 
-    ! Determine filename
-    IF     (C%choice_BIVgeo_method == 'CISM+' .OR. &
-            C%choice_BIVgeo_method == 'Berends2022') THEN
-      BIV_target%filename = C%BIVgeo_target_velocity_filename
-    ELSE
-      CALL crash('unknown choice_BIVgeo_method "' // TRIM(C%choice_BIVgeo_method) // '"!')
-    END IF
+    ! ! Determine filename
+    ! IF     (C%choice_BIVgeo_method == 'CISM+' .OR. &
+    !         C%choice_BIVgeo_method == 'Berends2022') THEN
+    !   BIV_target%filename = C%BIVgeo_target_velocity_filename
+    ! ELSE
+    !   CALL crash('unknown choice_BIVgeo_method "' // TRIM(C%choice_BIVgeo_method) // '"!')
+    ! END IF
 
-    IF (par%master) WRITE(0,*) '  Initialising basal inversion target velocity from file ', TRIM( BIV_target%filename), '...'
+    ! IF (par%master) WRITE(0,*) '  Initialising basal inversion target velocity from file ', TRIM( BIV_target%filename), '...'
 
-    ! Read input field
-    CALL read_BIV_target_velocity( BIV_target, region_name)
-    CALL sync
+    ! ! Read input field
+    ! CALL read_BIV_target_velocity( BIV_target, region_name)
+    ! CALL sync
 
-    ! NOTE: do not check for NaNs in the target velocity field. The Rignot 2011 Antarctica velocity product
-    !       has a lot of missing data points, indicated by NaN values. This is acceptable, the basal inversion
-    !       routine can handle that.
+    ! ! NOTE: do not check for NaNs in the target velocity field. The Rignot 2011 Antarctica velocity product
+    ! !       has a lot of missing data points, indicated by NaN values. This is acceptable, the basal inversion
+    ! !       routine can handle that.
 
-    ! CALL check_for_NaN_dp_2D( BIV_target%u_surf, 'BIV_target%u_surf')
-    ! CALL check_for_NaN_dp_2D( BIV_target%v_surf, 'BIV_target%v_surf')
+    ! ! CALL check_for_NaN_dp_2D( BIV_target%u_surf, 'BIV_target%u_surf')
+    ! ! CALL check_for_NaN_dp_2D( BIV_target%v_surf, 'BIV_target%v_surf')
 
-    CALL allocate_shared_dp_2D( BIV_target%grid%ny, BIV_target%grid%nx, BIV_target%uabs_surf, BIV_target%wuabs_surf)
+    ! CALL allocate_shared_dp_2D( BIV_target%grid%ny, BIV_target%grid%nx, BIV_target%uabs_surf, BIV_target%wuabs_surf)
 
-    ! Get absolute velocity
-    CALL partition_list( BIV_target%grid%nx, par%i, par%n, i1, i2)
-    DO i = i1, i2
-    DO j = 1, BIV_target%grid%ny
-      BIV_target%uabs_surf( i,j) = SQRT( BIV_target%u_surf( i,j)**2 + BIV_target%v_surf( i,j)**2)
-    END DO
-    END DO
-    CALL sync
+    ! ! Get absolute velocity
+    ! CALL partition_list( BIV_target%grid%nx, par%i, par%n, i1, i2)
+    ! DO i = i1, i2
+    ! DO j = 1, BIV_target%grid%ny
+    !   BIV_target%uabs_surf( i,j) = SQRT( BIV_target%u_surf( i,j)**2 + BIV_target%v_surf( i,j)**2)
+    ! END DO
+    ! END DO
+    ! CALL sync
 
-    ! Allocate shared memory
-    CALL allocate_shared_dp_2D( grid%ny, grid%nx, ice%BIV_uabs_surf_target, ice%wBIV_uabs_surf_target)
+    ! ! Allocate shared memory
+    ! CALL allocate_shared_dp_2D( grid%ny, grid%nx, ice%BIV_uabs_surf_target, ice%wBIV_uabs_surf_target)
 
-    ! Map (transposed) raw data to the model grid
-    CALL map_square_to_square_cons_2nd_order_2D( BIV_target%grid%nx, BIV_target%grid%ny, BIV_target%grid%x, BIV_target%grid%y, grid%nx, grid%ny, grid%x, grid%y, BIV_target%uabs_surf, ice%BIV_uabs_surf_target)
+    ! ! Map (transposed) raw data to the model grid
+    ! CALL map_square_to_square_cons_2nd_order_2D( BIV_target%grid%nx, BIV_target%grid%ny, BIV_target%grid%x, BIV_target%grid%y, grid%nx, grid%ny, grid%x, grid%y, BIV_target%uabs_surf, ice%BIV_uabs_surf_target)
 
-
-    ! Deallocate raw data
-    CALL deallocate_grid(   BIV_target%grid      )
-    CALL deallocate_shared( BIV_target%wu_surf   )
-    CALL deallocate_shared( BIV_target%wv_surf   )
-    CALL deallocate_shared( BIV_target%wuabs_surf)
+    ! ! Deallocate raw data
+    ! CALL deallocate_grid(   BIV_target%grid      )
+    ! CALL deallocate_shared( BIV_target%wu_surf   )
+    ! CALL deallocate_shared( BIV_target%wv_surf   )
+    ! CALL deallocate_shared( BIV_target%wuabs_surf)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)
@@ -2474,58 +2473,60 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    IF (.NOT. par%master) THEN
-      CALL finalise_routine( routine_name)
-      RETURN
-    END IF
+    call crash('This routines needs to be tested and fixed regarding NetCDF I/O')
 
-    CALL read_field_from_xy_file_2D(           BIV_target%filename, 'u_surf', region_name, BIV_target%grid, BIV_target%u_surf,BIV_target%wu_surf)
-    CALL read_field_from_xy_file_2D(           BIV_target%filename, 'v_surf', region_name, BIV_target%grid, BIV_target%v_surf,BIV_target%wv_surf)
+    ! IF (.NOT. par%master) THEN
+    !   CALL finalise_routine( routine_name)
+    !   RETURN
+    ! END IF
 
-    ! Exception: for some reason, the Rignot 2011 data has the y-axis reversed...
-    is_Rignot2011 = .FALSE.
-    DO i = 1, 256-36
-      IF (BIV_target%filename(i:i+33) == 'antarctica_ice_velocity_450m_v2.nc') THEN
-        is_Rignot2011 = .TRUE.
-      END IF
-    END DO
-    IF (is_Rignot2011) THEN
+    ! CALL read_field_from_xy_file_2D(           BIV_target%filename, 'u_surf', region_name, BIV_target%grid, BIV_target%u_surf,BIV_target%wu_surf)
+    ! CALL read_field_from_xy_file_2D(           BIV_target%filename, 'v_surf', region_name, BIV_target%grid, BIV_target%v_surf,BIV_target%wv_surf)
 
-      ! Allocate temporary memory for storing the upside-down data
-      ALLOCATE( y_temp( BIV_target%grid%ny))
-      ALLOCATE( u_temp( BIV_target%grid%nx, BIV_target%grid%ny))
-      ALLOCATE( v_temp( BIV_target%grid%nx, BIV_target%grid%ny))
+    ! ! Exception: for some reason, the Rignot 2011 data has the y-axis reversed...
+    ! is_Rignot2011 = .FALSE.
+    ! DO i = 1, 256-36
+    !   IF (BIV_target%filename(i:i+33) == 'antarctica_ice_velocity_450m_v2.nc') THEN
+    !     is_Rignot2011 = .TRUE.
+    !   END IF
+    ! END DO
+    ! IF (is_Rignot2011) THEN
 
-      ! Copy the upside-down data to temporary memory
-      y_temp = BIV_target%grid%y
-      u_temp = BIV_target%u_surf
-      v_temp = BIV_target%v_surf
+    !   ! Allocate temporary memory for storing the upside-down data
+    !   ALLOCATE( y_temp( BIV_target%grid%ny))
+    !   ALLOCATE( u_temp( BIV_target%grid%nx, BIV_target%grid%ny))
+    !   ALLOCATE( v_temp( BIV_target%grid%nx, BIV_target%grid%ny))
 
-      ! Flip the data
-      DO j = 1, BIV_target%grid%ny
-        BIV_target%grid%y(   j) = y_temp(   BIV_target%grid%ny + 1 - j)
-        BIV_target%u_surf( :,j) = u_temp( :,BIV_target%grid%ny + 1 - j)
-        BIV_target%v_surf( :,j) = v_temp( :,BIV_target%grid%ny + 1 - j)
-      END DO
+    !   ! Copy the upside-down data to temporary memory
+    !   y_temp = BIV_target%grid%y
+    !   u_temp = BIV_target%u_surf
+    !   v_temp = BIV_target%v_surf
 
-      ! Deallocate temporary memory
-      DEALLOCATE( y_temp)
-      DEALLOCATE( u_temp)
-      DEALLOCATE( v_temp)
+    !   ! Flip the data
+    !   DO j = 1, BIV_target%grid%ny
+    !     BIV_target%grid%y(   j) = y_temp(   BIV_target%grid%ny + 1 - j)
+    !     BIV_target%u_surf( :,j) = u_temp( :,BIV_target%grid%ny + 1 - j)
+    !     BIV_target%v_surf( :,j) = v_temp( :,BIV_target%grid%ny + 1 - j)
+    !   END DO
 
-      ! Set missing values to NaN
-      NaN = 0._dp
-      NaN = 0._dp / NaN
-      DO i = 1, BIV_target%grid%nx
-      DO j = 1, BIV_target%grid%ny
-        IF (BIV_target%u_surf( i,j) == 0._dp .AND. BIV_target%v_surf( i,j) == 0._dp) THEN
-          BIV_target%u_surf( i,j) = NaN
-          BIV_target%v_surf( i,j) = NaN
-        END IF
-      END DO
-      END DO
+    !   ! Deallocate temporary memory
+    !   DEALLOCATE( y_temp)
+    !   DEALLOCATE( u_temp)
+    !   DEALLOCATE( v_temp)
 
-    END IF ! IF (is_Rignot2011) THEN
+    !   ! Set missing values to NaN
+    !   NaN = 0._dp
+    !   NaN = 0._dp / NaN
+    !   DO i = 1, BIV_target%grid%nx
+    !   DO j = 1, BIV_target%grid%ny
+    !     IF (BIV_target%u_surf( i,j) == 0._dp .AND. BIV_target%v_surf( i,j) == 0._dp) THEN
+    !       BIV_target%u_surf( i,j) = NaN
+    !       BIV_target%v_surf( i,j) = NaN
+    !     END IF
+    !   END DO
+    !   END DO
+
+    ! END IF ! IF (is_Rignot2011) THEN
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)

--- a/src/calving_module.f90
+++ b/src/calving_module.f90
@@ -77,7 +77,7 @@ CONTAINS
     ! Apply calving law
     DO i = grid%i1, grid%i2
     DO j = 1, grid%ny
-      IF (ice%mask_cf_a( j,i) == 1 .AND. ice%Hi_eff_cf_a( j,i) < C%calving_threshold_thickness) THEN
+      IF (ice%mask_cf_a( j,i) == 1 .AND. ice%mask_shelf_a( j,i) == 1 .AND. ice%Hi_eff_cf_a( j,i) < C%calving_threshold_thickness) THEN
         ice%Hi_a( j,i) = 0._dp
       END IF
     END DO

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -259,6 +259,9 @@ MODULE configuration_module
   REAL(dp)            :: insolation_weigth_mean_ANT_config           = 440                              ! (W/m2) insolation at which insolation does not alter the external forcing (w_INS = 0)
   REAL(dp)            :: insolation_weigth_amplitude_ANT_config      = 70                               ! (W/m2) the amplitude at which insolation affects the interpolation weight.
 
+  ! Determine if the GCM wind is used in the climate matrix method
+  LOGICAL             :: do_climate_matrix_wind_config               = .TRUE.                            ! If TRUE, use the wind from the climate forcing. If FALSE, use the wind from the reference climate.
+
   ! Geothermal heat flux
   CHARACTER(LEN=256)  :: choice_geothermal_heat_flux_config          = 'spatial'                        ! Choice of geothermal heat flux; can be 'constant' or 'spatial'
   REAL(dp)            :: constant_geothermal_heat_flux_config        = 1.72E06_dp                       ! Geothermal Heat flux [J m^-2 yr^-1] Sclater et al. (1980)
@@ -519,7 +522,7 @@ MODULE configuration_module
 
   ! Whether or not to apply a bias correction to the GCM snapshots
   LOGICAL             :: climate_matrix_biascorrect_warm_config      = .TRUE.                           ! Whether or not to apply a bias correction (modelled vs observed PI climate) to the "warm" GCM snapshot
-  LOGICAL             :: climate_matrix_biascorrect_cold_config      = .TRUE.                           ! Whether or not to apply a bias correction (modelled vs observed PI climate) to the "cold" GCM snapshot
+  LOGICAL             :: climate_matrix_biascorrect_cold_config      = .FALSE.                          ! Whether or not to apply a bias correction (modelled vs observed PI climate) to the "cold" GCM snapshot
 
   LOGICAL             :: switch_glacial_index_precip_config          = .FALSE.                          ! If a glacial index is used for the precipitation forcing, it will only depend on CO2
 
@@ -1067,15 +1070,18 @@ MODULE configuration_module
     CHARACTER(LEN=256)                  :: filename_d18O_record
     INTEGER                             :: d18O_record_length
 
-    LOGICAL                            :: do_combine_CO2_and_insolation
-    REAL(dp)                           :: insolation_weigth_mean_NAM         
-    REAL(dp)                           :: insolation_weigth_amplitude_NAM    
-    REAL(dp)                           :: insolation_weigth_mean_EAS         
-    REAL(dp)                           :: insolation_weigth_amplitude_EAS    
-    REAL(dp)                           :: insolation_weigth_mean_GRL         
-    REAL(dp)                           :: insolation_weigth_amplitude_GRL    
-    REAL(dp)                           :: insolation_weigth_mean_ANT         
-    REAL(dp)                           :: insolation_weigth_amplitude_ANT
+    LOGICAL                             :: do_combine_CO2_and_insolation
+    REAL(dp)                            :: insolation_weigth_mean_NAM         
+    REAL(dp)                            :: insolation_weigth_amplitude_NAM    
+    REAL(dp)                            :: insolation_weigth_mean_EAS         
+    REAL(dp)                            :: insolation_weigth_amplitude_EAS    
+    REAL(dp)                            :: insolation_weigth_mean_GRL         
+    REAL(dp)                            :: insolation_weigth_amplitude_GRL    
+    REAL(dp)                            :: insolation_weigth_mean_ANT         
+    REAL(dp)                            :: insolation_weigth_amplitude_ANT
+
+    ! Climate matrix wind
+    LOGICAL                             :: do_climate_matrix_wind
 
     ! Geothermal heat flux
     CHARACTER(LEN=256)                  :: choice_geothermal_heat_flux
@@ -2032,6 +2038,7 @@ CONTAINS
                      insolation_weigth_amplitude_GRL_config,          &
                      insolation_weigth_mean_ANT_config,               &
                      insolation_weigth_amplitude_ANT_config,          &
+                     do_climate_matrix_wind_config,                   &
                      choice_geothermal_heat_flux_config,              &
                      constant_geothermal_heat_flux_config,            &
                      filename_geothermal_heat_flux_config,            &
@@ -2846,6 +2853,9 @@ CONTAINS
     C%insolation_weigth_amplitude_GRL          = insolation_weigth_amplitude_GRL_config
     C%insolation_weigth_mean_ANT               = insolation_weigth_mean_ANT_config
     C%insolation_weigth_amplitude_ANT          = insolation_weigth_amplitude_ANT_config
+
+    ! Climate matrix wind
+    C%do_climate_matrix_wind                   = do_climate_matrix_wind_config
 
     ! Geothermal heat flux
     C%choice_geothermal_heat_flux              = choice_geothermal_heat_flux_config

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -98,11 +98,12 @@ MODULE configuration_module
   ! This works fine locally, on LISA its better to use a fixed folder name.
   ! =======================================================================
 
-  LOGICAL             :: create_procedural_output_dir_config         = .TRUE.                           ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
-  CHARACTER(LEN=256)  :: fixed_output_dir_config                     = 'results_IMAU_ICE'               ! If not, create a directory with this name instead (stops the program if this directory already exists)
-  CHARACTER(LEN=256)  :: fixed_output_dir_suffix_config              = ''                               ! Suffix to put after the fixed output directory name, useful when doing ensemble runs with the template+variation set-up
-  LOGICAL             :: do_write_regional_scalar_output_config      = .TRUE.
-  LOGICAL             :: do_write_global_scalar_output_config        = .TRUE.
+  LOGICAL             :: create_procedural_output_dir_config            = .TRUE.                           ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+  CHARACTER(LEN=256)  :: fixed_output_dir_config                        = 'results_IMAU_ICE'               ! If not, create a directory with this name instead (stops the program if this directory already exists)
+  CHARACTER(LEN=256)  :: fixed_output_dir_suffix_config                 = ''                               ! Suffix to put after the fixed output directory name, useful when doing ensemble runs with the template+variation set-up
+  LOGICAL             :: do_write_regional_scalar_output_config         = .TRUE.
+  LOGICAL             :: do_write_global_scalar_output_config           = .TRUE.
+  LOGICAL             :: do_write_regional_scalar_every_timestep_config = .FALSE.
 
   ! Debugging
   ! =========
@@ -246,6 +247,17 @@ MODULE configuration_module
   ! d18O record (ASCII text file, so the number of rows needs to be specified)
   CHARACTER(LEN=256)  :: filename_d18O_record_config                 = '/Users/berends/Documents/Datasets/d18O/Ahn2017_d18O.dat'
   INTEGER             :: d18O_record_length_config                   = 2051
+
+  ! Parameters for combining insolation and CO2 in the matrix method
+  LOGICAL             :: do_combine_CO2_and_insolation_config        = .FALSE.                          ! Combine the effect of insolation and CO2 to calculate the external forcing in the matrix method
+  REAL(dp)            :: insolation_weigth_mean_NAM_config           = 440                              ! (W/m2) insolation at which insolation does not alter the external forcing (w_INS = 0)
+  REAL(dp)            :: insolation_weigth_amplitude_NAM_config      = 70                               ! (W/m2) the amplitude at which insolation affects the interpolation weight.
+  REAL(dp)            :: insolation_weigth_mean_EAS_config           = 440                              ! (W/m2) insolation at which insolation does not alter the external forcing (w_INS = 0)
+  REAL(dp)            :: insolation_weigth_amplitude_EAS_config      = 70                               ! (W/m2) the amplitude at which insolation affects the interpolation weight.
+  REAL(dp)            :: insolation_weigth_mean_GRL_config           = 440                              ! (W/m2) insolation at which insolation does not alter the external forcing (w_INS = 0)
+  REAL(dp)            :: insolation_weigth_amplitude_GRL_config      = 70                               ! (W/m2) the amplitude at which insolation affects the interpolation weight.
+  REAL(dp)            :: insolation_weigth_mean_ANT_config           = 440                              ! (W/m2) insolation at which insolation does not alter the external forcing (w_INS = 0)
+  REAL(dp)            :: insolation_weigth_amplitude_ANT_config      = 70                               ! (W/m2) the amplitude at which insolation affects the interpolation weight.
 
   ! Geothermal heat flux
   CHARACTER(LEN=256)  :: choice_geothermal_heat_flux_config          = 'spatial'                        ! Choice of geothermal heat flux; can be 'constant' or 'spatial'
@@ -482,6 +494,15 @@ MODULE configuration_module
   CHARACTER(LEN=256)  :: filename_climate_snapshot_warm_config       = '/Users/berends/Documents/Datasets/GCM_snapshots/Singarayer_Valdes_2010_PI_Control.nc'
   CHARACTER(LEN=256)  :: filename_climate_snapshot_cold_config       = '/Users/berends/Documents/Datasets/GCM_snapshots/Singarayer_Valdes_2010_LGM.nc'
 
+  ! Ice and ocean mask from GCM snapshots
+  CHARACTER(LEN=256)  :: reference_mask_method_config                = 'estimate'                        ! 'estimate' (based on GCM topography and temperature) or 'file' from a selected file
+  
+  CHARACTER(LEN=256)  :: filename_snapshot_mask_PD_obs_config        = ''   
+  CHARACTER(LEN=256)  :: filename_snapshot_mask_GCM_PI_config        = ''
+  CHARACTER(LEN=256)  :: filename_snapshot_mask_GCM_warm_config      = ''
+  CHARACTER(LEN=256)  :: filename_snapshot_mask_GCM_cold_config      = ''
+  
+  ! Lapse rate
   REAL(dp)            :: constant_lapserate_config                   = 0.008_dp                         ! Constant atmospheric lapse rate [K m^-1]
 
   ! Scaling factor for CO2 vs ice weights
@@ -920,6 +941,7 @@ MODULE configuration_module
     CHARACTER(LEN=256)                  :: fixed_output_dir_suffix
     LOGICAL                             :: do_write_regional_scalar_output
     LOGICAL                             :: do_write_global_scalar_output
+    LOGICAL                             :: do_write_regional_scalar_every_timestep
 
     ! Debugging
     ! =========
@@ -1044,6 +1066,16 @@ MODULE configuration_module
     ! d18O record (ASCII text file, so the number of rows needs to be specified)
     CHARACTER(LEN=256)                  :: filename_d18O_record
     INTEGER                             :: d18O_record_length
+
+    LOGICAL                            :: do_combine_CO2_and_insolation
+    REAL(dp)                           :: insolation_weigth_mean_NAM         
+    REAL(dp)                           :: insolation_weigth_amplitude_NAM    
+    REAL(dp)                           :: insolation_weigth_mean_EAS         
+    REAL(dp)                           :: insolation_weigth_amplitude_EAS    
+    REAL(dp)                           :: insolation_weigth_mean_GRL         
+    REAL(dp)                           :: insolation_weigth_amplitude_GRL    
+    REAL(dp)                           :: insolation_weigth_mean_ANT         
+    REAL(dp)                           :: insolation_weigth_amplitude_ANT
 
     ! Geothermal heat flux
     CHARACTER(LEN=256)                  :: choice_geothermal_heat_flux
@@ -1279,6 +1311,15 @@ MODULE configuration_module
     CHARACTER(LEN=256)                  :: filename_climate_snapshot_warm
     CHARACTER(LEN=256)                  :: filename_climate_snapshot_cold
 
+    ! Ice and ocean mask from GCM snapshots
+    CHARACTER(LEN=256)                  :: reference_mask_method
+    
+    CHARACTER(LEN=256)                  :: filename_snapshot_mask_PD_obs 
+    CHARACTER(LEN=256)                  :: filename_snapshot_mask_GCM_PI
+    CHARACTER(LEN=256)                  :: filename_snapshot_mask_GCM_warm
+    CHARACTER(LEN=256)                  :: filename_snapshot_mask_GCM_cold  
+  
+    ! Lapse rate
     REAL(dp)                            :: constant_lapserate
 
     ! Scaling factor for CO2 vs ice weights
@@ -1900,6 +1941,7 @@ CONTAINS
                      fixed_output_dir_suffix_config,                  &
                      do_write_regional_scalar_output_config,          &
                      do_write_global_scalar_output_config,            &
+                     do_write_regional_scalar_every_timestep_config,  &
                      do_check_for_NaN_config,                         &
                      do_time_display_config,                          &
                      do_write_ISMIP_output_config,                    &
@@ -1981,6 +2023,15 @@ CONTAINS
                      CO2_record_length_config,                        &
                      filename_d18O_record_config,                     &
                      d18O_record_length_config,                       &
+                     do_combine_CO2_and_insolation_config,            &
+                     insolation_weigth_mean_NAM_config,               &
+                     insolation_weigth_amplitude_NAM_config,          &
+                     insolation_weigth_mean_EAS_config,               &
+                     insolation_weigth_amplitude_EAS_config,          &
+                     insolation_weigth_mean_GRL_config ,              &
+                     insolation_weigth_amplitude_GRL_config,          &
+                     insolation_weigth_mean_ANT_config,               &
+                     insolation_weigth_amplitude_ANT_config,          &
                      choice_geothermal_heat_flux_config,              &
                      constant_geothermal_heat_flux_config,            &
                      filename_geothermal_heat_flux_config,            &
@@ -2157,6 +2208,11 @@ CONTAINS
                      filename_climate_snapshot_PI_config,             &
                      filename_climate_snapshot_warm_config,           &
                      filename_climate_snapshot_cold_config,           &
+                     reference_mask_method_config,                    &      
+                     filename_snapshot_mask_PD_obs_config,            &
+                     filename_snapshot_mask_GCM_PI_config,            &
+                     filename_snapshot_mask_GCM_warm_config,          &
+                     filename_snapshot_mask_GCM_cold_config,          &
                      constant_lapserate_config,                       &
                      climate_matrix_CO2vsice_NAM_config,              &
                      climate_matrix_CO2vsice_EAS_config,              &
@@ -2653,7 +2709,7 @@ CONTAINS
     C%fixed_output_dir_suffix                  = fixed_output_dir_suffix_config
     C%do_write_regional_scalar_output          = do_write_regional_scalar_output_config
     C%do_write_global_scalar_output            = do_write_global_scalar_output_config
-
+    C%do_write_regional_scalar_every_timestep  = do_write_regional_scalar_every_timestep_config
     ! Debugging
     ! =========
 
@@ -2778,6 +2834,18 @@ CONTAINS
     ! d18O record (ASCII text file, so the number of rows needs to be specified)
     C%filename_d18O_record                     = filename_d18O_record_config
     C%d18O_record_length                       = d18O_record_length_config
+
+    ! Parameters for combining insolation and CO2 in the matrix method
+    C%do_combine_CO2_and_insolation            = do_combine_CO2_and_insolation_config
+    
+    C%insolation_weigth_mean_NAM               = insolation_weigth_mean_NAM_config
+    C%insolation_weigth_amplitude_NAM          = insolation_weigth_amplitude_NAM_config
+    C%insolation_weigth_mean_EAS               = insolation_weigth_mean_EAS_config
+    C%insolation_weigth_amplitude_EAS          = insolation_weigth_amplitude_EAS_config
+    C%insolation_weigth_mean_GRL               = insolation_weigth_mean_GRL_config
+    C%insolation_weigth_amplitude_GRL          = insolation_weigth_amplitude_GRL_config
+    C%insolation_weigth_mean_ANT               = insolation_weigth_mean_ANT_config
+    C%insolation_weigth_amplitude_ANT          = insolation_weigth_amplitude_ANT_config
 
     ! Geothermal heat flux
     C%choice_geothermal_heat_flux              = choice_geothermal_heat_flux_config
@@ -3013,7 +3081,16 @@ CONTAINS
     C%filename_climate_snapshot_PI             = filename_climate_snapshot_PI_config
     C%filename_climate_snapshot_warm           = filename_climate_snapshot_warm_config
     C%filename_climate_snapshot_cold           = filename_climate_snapshot_cold_config
+    
+    ! GCM snapshots in the matrix_warm_cold option
+    C%reference_mask_method                    = reference_mask_method_config 
+    
+    C%filename_snapshot_mask_PD_obs            = filename_snapshot_mask_PD_obs_config
+    C%filename_snapshot_mask_GCM_PI            = filename_snapshot_mask_GCM_PI_config
+    C%filename_snapshot_mask_GCM_warm          = filename_snapshot_mask_GCM_warm_config
+    C%filename_snapshot_mask_GCM_cold          = filename_snapshot_mask_GCM_cold_config
 
+    ! Constant lapse rate
     C%constant_lapserate                       = constant_lapserate_config
 
     ! Scaling factor for CO2 vs ice weights

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -492,7 +492,10 @@ MODULE data_types_module
     ! GCM bias
     REAL(dp), DIMENSION(:,:,:), POINTER     :: GCM_bias_T2m
     REAL(dp), DIMENSION(:,:,:), POINTER     :: GCM_bias_Precip
-    INTEGER :: wGCM_bias_T2m, wGCM_bias_Precip
+    REAL(dp), DIMENSION(:,:  ), POINTER     :: GCM_bias_Hs
+    REAL(dp), DIMENSION(:,:,:), POINTER     :: GCM_bias_Wind_LR
+    REAL(dp), DIMENSION(:,:,:), POINTER     :: GCM_bias_Wind_DU
+    INTEGER :: wGCM_bias_T2m, wGCM_bias_Precip, wGCM_bias_Hs, wGCM_bias_Wind_LR, wGCM_bias_Wind_DU
 
     ! Climate matrix interpolation 
     REAL(dp), DIMENSION(:,:), POINTER     :: w_ins_T

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -14,11 +14,10 @@ MODULE data_types_module
     ! A regular square grid
 
     INTEGER,                    POINTER     :: nx, ny, n
-    REAL(dp),                   POINTER     :: dx, tol_dist
-    INTEGER,  DIMENSION(:,:  ), POINTER     :: ij2n, n2ij
+    REAL(dp),                   POINTER     :: dx
     REAL(dp), DIMENSION(:    ), POINTER     :: x, y
     REAL(dp),                   POINTER     :: xmin, xmax, ymin, ymax
-    INTEGER :: wnx, wny, wn, wdx, wtol_dist, wij2n, wn2ij, wx, wy, wxmin, wxmax, wymin, wymax
+    INTEGER :: wnx, wny, wn, wdx, wx, wy, wxmin, wxmax, wymin, wymax
     INTEGER                                 :: i1, i2, j1, j2 ! Parallelisation by domain decomposition
 
     REAL(dp),                   POINTER     :: lambda_M

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -372,13 +372,16 @@ MODULE data_types_module
 
     ! Climate data
     REAL(dp), DIMENSION(:,:  ), POINTER     :: Hs                            ! Orography (m w.r.t. PD sea level)
+    INTEGER, DIMENSION(:,:  ), POINTER     :: mask_ice                      ! Climate snapshot ice (1) no_ice (1) mask
+    INTEGER, DIMENSION(:,:  ), POINTER     :: mask_ocean                    ! Climate snapshot ocean (1) land (0) mask
+    INTEGER, DIMENSION(:,:  ), POINTER     :: mask_shelf                    ! Climate snapshot shelf (1) no shelf (0) mask
     REAL(dp), DIMENSION(:,:,:), POINTER     :: T2m                           ! Monthly mean 2m air temperature (K)
     REAL(dp), DIMENSION(:,:,:), POINTER     :: Precip                        ! Monthly mean precipitation (m)
     REAL(dp), DIMENSION(:,:,:), POINTER     :: Wind_WE                       ! Monthly mean west-east   wind speed (m/s)
     REAL(dp), DIMENSION(:,:,:), POINTER     :: Wind_SN                       ! Monthly mean south-north wind speed (m/s)
     REAL(dp), DIMENSION(:,:,:), POINTER     :: Wind_LR                       ! Monthly mean wind speed in the x-direction (m/s)
     REAL(dp), DIMENSION(:,:,:), POINTER     :: Wind_DU                       ! Monthly mean wind speed in the y-direction (m/s)
-    INTEGER :: wHs, wT2m, wPrecip, wHs_ref, wWind_WE, wWind_SN, wWind_LR, wWind_DU
+    INTEGER :: wHs, wmask_ice, wmask_ocean, wmask_shelf, wT2m, wPrecip, wHs_ref, wWind_WE, wWind_SN, wWind_LR, wWind_DU
 
     ! Spatially variable lapse rate for GCM snapshots (see Berends et al., 2018)
     REAL(dp), DIMENSION(:,:  ), POINTER     :: lambda
@@ -490,6 +493,18 @@ MODULE data_types_module
     REAL(dp), DIMENSION(:,:,:), POINTER     :: GCM_bias_T2m
     REAL(dp), DIMENSION(:,:,:), POINTER     :: GCM_bias_Precip
     INTEGER :: wGCM_bias_T2m, wGCM_bias_Precip
+
+    ! Climate matrix interpolation 
+    REAL(dp), DIMENSION(:,:), POINTER     :: w_ins_T
+    REAL(dp), DIMENSION(:,:), POINTER     :: w_ice_T
+    REAL(dp), DIMENSION(:,:), POINTER     :: w_tot_T
+    REAL(dp), DIMENSION(:,:), POINTER     :: w_warm_P
+    REAL(dp), DIMENSION(:,:), POINTER     :: w_cold_P
+    REAL(dp),                 POINTER     :: w_tot_P
+    INTEGER :: ww_tot_T, ww_ins_T, ww_ice_T, ww_warm_P, ww_cold_P, ww_tot_P
+
+    REAL(dp), POINTER                     :: w_EXT
+    INTEGER :: ww_EXT
 
     ! Total yearly absorbed insolation, used in the climate matrix for interpolation
     REAL(dp), DIMENSION(:,:  ), POINTER     :: I_abs
@@ -906,8 +921,9 @@ MODULE data_types_module
     REAL(dp), DIMENSION(:    ), POINTER     :: ins_lat
     REAL(dp),                   POINTER     :: ins_t0, ins_t1
     REAL(dp), DIMENSION(:,:  ), POINTER     :: ins_Q_TOA0, ins_Q_TOA1
-    INTEGER :: wins_nyears, wins_nlat, wins_time, wins_lat, wins_t0, wins_t1, wins_Q_TOA0, wins_Q_TOA1
-
+    REAL(dp),                   POINTER     :: Q_TOA_JJA_65N, Q_TOA_DJF_80S
+    INTEGER :: wins_nyears, wins_nlat, wins_time, wins_lat, wins_t0, wins_t1, wins_Q_TOA0, wins_Q_TOA1, wQ_TOA_JJA_65N, wQ_TOA_DJF_80S
+    
     ! External forcing: sea level record
     REAL(dp), DIMENSION(:    ), POINTER     :: sealevel_time
     REAL(dp), DIMENSION(:    ), POINTER     :: sealevel_record

--- a/src/ice_thickness_module.f90
+++ b/src/ice_thickness_module.f90
@@ -1130,6 +1130,8 @@ CONTAINS
     ! Read data from file
     CALL read_field_from_file_2D( C%target_dhdt_filename, 'dHdt', grid, ice%dHi_dt_target, region_name)
 
+    CALL check_for_NaN_dp_2D( ice%dHi_dt_target, 'ice%dHi_dt_target')
+
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 

--- a/src/netcdf_basic_module.f90
+++ b/src/netcdf_basic_module.f90
@@ -56,7 +56,7 @@ MODULE netcdf_basic_module
   CHARACTER(LEN=256), PARAMETER :: field_name_options_lat            = 'lat||Lat||latitude||Latitude'
   CHARACTER(LEN=256), PARAMETER :: field_name_options_time           = 'time||Time||t||nt'
   CHARACTER(LEN=256), PARAMETER :: field_name_options_month          = 'month||Month'
-
+  
   ! Variables
   CHARACTER(LEN=256), PARAMETER :: field_name_options_Hi             = 'Hi||thickness||lithk'
   CHARACTER(LEN=256), PARAMETER :: field_name_options_Hb             = 'Hb||bed||topg'
@@ -69,6 +69,10 @@ MODULE netcdf_basic_module
   CHARACTER(LEN=256), PARAMETER :: field_name_options_T_ocean        = 'T_ocean||t_an'
   CHARACTER(LEN=256), PARAMETER :: field_name_options_S_ocean        = 'S_ocean||s_an'
   CHARACTER(LEN=256), PARAMETER :: field_name_options_melt           = 'melt'
+  CHARACTER(LEN=256), PARAMETER :: field_name_options_wind_WE        = 'Wind_WE||uas'
+  CHARACTER(LEN=256), PARAMETER :: field_name_options_wind_SN        = 'Wind_SN||vas'
+  CHARACTER(LEN=256), PARAMETER :: field_name_options_mask_ice       = 'sftgif'
+  CHARACTER(LEN=256), PARAMETER :: field_name_options_mask_ocean     = 'sftlf'
 
 
 CONTAINS
@@ -2209,6 +2213,15 @@ CONTAINS
         field_name_options_parsed = field_name_options_S_ocean
       ELSEIF (field_name_options == 'default_options_melt') THEN
         field_name_options_parsed = field_name_options_melt
+      ELSEIF (field_name_options == 'default_options_mask_ice') THEN
+        field_name_options_parsed = field_name_options_mask_ice
+      ELSEIF (field_name_options == 'default_options_mask_ocean') THEN
+        field_name_options_parsed = field_name_options_mask_ocean
+      ELSEIF (field_name_options == 'field_name_options_wind_WE') THEN
+        field_name_options_parsed = field_name_options_wind_WE
+      ELSEIF (field_name_options == 'field_name_options_wind_SN') THEN
+        field_name_options_parsed = field_name_options_wind_SN
+
       ! Unrecognised default options
       ELSE
         CALL crash('unregocnised default field name option "' // TRIM( field_name_options) // '"')

--- a/src/netcdf_input_module.f90
+++ b/src/netcdf_input_module.f90
@@ -638,6 +638,8 @@ CONTAINS
 
     ! Transpose the input data
     CALL transpose_dp_2D( d, wd)
+    CALL transpose_dp_2D( grid%lon, grid%wlon)
+    CALL transpose_dp_2D( grid%lat, grid%wlat)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name, 19)
@@ -763,6 +765,8 @@ CONTAINS
 
     ! Transpose the input data
     CALL transpose_dp_3D( d, wd )
+    CALL transpose_dp_2D( grid%lon, grid%wlon)
+    CALL transpose_dp_2D( grid%lat, grid%wlat)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name, 19)
@@ -902,6 +906,8 @@ CONTAINS
 
     ! Transpose the input data
     CALL transpose_dp_3D( d, wd )
+    CALL transpose_dp_2D( grid%lon, grid%wlon)
+    CALL transpose_dp_2D( grid%lat, grid%wlat)
 
     ! Clean up after yourself
     CALL deallocate_shared(   wzeta_from_file)
@@ -1473,7 +1479,7 @@ CONTAINS
     INTEGER                                            :: wntime_history, wtime_history,wd_with_time
     INTEGER                                            :: ti
 
-    
+
     ! Add routine to path
     CALL init_routine( routine_name)
 
@@ -1512,16 +1518,16 @@ CONTAINS
       CALL find_timeframe( filename, time_to_read, ti)
       ! Read data
       CALL read_var_dp_2D( filename, id_var, d_with_time, start = (/ 1, ti /), count = (/ ntime_history, 1 /) )
-      
+
       ! Copy to output memory
-      IF (par%master) THEN  
+      IF (par%master) THEN
          d( :) = d_with_time( :,1)
-      END IF 
+      END IF
       CALL sync
 
       ! Clean up after yourself
       CALL deallocate_shared( wd_with_time)
-      
+
    END IF
 
    CALL deallocate_shared( wntime_history)
@@ -1531,7 +1537,7 @@ CONTAINS
    CALL finalise_routine( routine_name, 19)
 
    END SUBROUTINE read_field_from_file_history_1D
- 
+
   ! ===== Set up grids from a NetCDF file =====
   ! ================================================
 
@@ -1589,9 +1595,6 @@ CONTAINS
     CALL allocate_shared_dp_0D(                    grid%ymin       , grid%wymin       )
     CALL allocate_shared_dp_0D(                    grid%ymax       , grid%wymax       )
     CALL allocate_shared_dp_0D(                    grid%dx         , grid%wdx         )
-    CALL allocate_shared_dp_0D(                    grid%tol_dist   , grid%wtol_dist   )
-    CALL allocate_shared_int_2D( grid%nx, grid%ny, grid%ij2n       , grid%wij2n       )
-    CALL allocate_shared_int_2D( grid%n , 2,       grid%n2ij       , grid%wn2ij       )
     CALL allocate_shared_dp_0D(                    grid%lambda_m   , grid%wlambda_m   )
     CALL allocate_shared_dp_0D(                    grid%phi_m      , grid%wphi_m      )
     CALL allocate_shared_dp_0D(                    grid%beta_stereo, grid%wbeta_stereo)
@@ -1617,27 +1620,6 @@ CONTAINS
       grid%xmax = MAXVAL( grid%x)
       grid%ymin = MINVAL( grid%y)
       grid%ymax = MAXVAL( grid%y)
-
-      ! Tolerance; points lying within this distance of each other are treated as identical
-      grid%tol_dist = ((grid%xmax - grid%xmin) + (grid%ymax - grid%ymin)) * tol / 2._dp
-
-      ! Conversion tables for grid-form vs. vector-form data
-      n = 0
-      DO i = 1, grid%nx
-        IF (MOD(i,2) == 1) THEN
-          DO j = 1, grid%ny
-            n = n+1
-            grid%ij2n( i,j) = n
-            grid%n2ij( n,:) = [i,j]
-          END DO
-        ELSE
-          DO j = grid%ny, 1, -1
-            n = n+1
-            grid%ij2n( i,j) = n
-            grid%n2ij( n,:) = [i,j]
-          END DO
-        END IF
-      END DO
 
     END IF ! IF (par%master) THEN
     CALL sync
@@ -1674,7 +1656,7 @@ CONTAINS
     CALL sync
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name, 18)
+    CALL finalise_routine( routine_name, 15)
 
   END SUBROUTINE setup_xy_grid_from_file
 

--- a/src/netcdf_output_module.f90
+++ b/src/netcdf_output_module.f90
@@ -418,13 +418,13 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    ! Variable name for the time_history dimension 
+    ! Variable name for the time_history dimension
     var_name_time_history = 'time_' // TRIM( var_name)
 
     CALL allocate_shared_dp_1D(      ntime_history, time_history, wtime_history )
 
     DO i = 1,ntime_history
-        time_history( i) = -i * C%dt_coupling 
+        time_history( i) = -i * C%dt_coupling
     END DO
 
     ! Add the time_history to file
@@ -454,7 +454,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE add_field_history_dp_1D
-  
+
   SUBROUTINE create_restart_file_grid( filename, grid)
     ! Create an empty restart file with the specified grid
 
@@ -480,11 +480,11 @@ CONTAINS
     CALL add_time_dimension_to_file(  filename)
     CALL add_zeta_dimension_to_file(  filename)
     CALL add_month_dimension_to_file( filename)
-    
+
     ! Add a time_history dimension for the inverse 18O simulation
     !IF (C%choice_forcing_method == 'd18O_inverse_CO2' .OR. &
     !   (C%choice_forcing_method == 'd18O_inverse_dT_glob')) THEN
-    !    CALL add_time_history_dimension_to_file(  filename)    
+    !    CALL add_time_history_dimension_to_file(  filename)
     !END IF
 
     ! Create variables
@@ -1011,19 +1011,19 @@ CONTAINS
     ELSE
       CALL crash('unknown choice_ice_isotopes_model "' // TRIM(C%choice_ice_isotopes_model) // '"!')
     END IF
-    
+
     ! Inverse routine data
     IF (C%choice_forcing_method == 'd18O_inverse_CO2') THEN
       IF (.NOT.(PRESENT( forcing))) CALL crash('write_to_restart_file_grid needs forcing field if d18O_inverse_CO2 is used')
       CALL write_to_field_history_dp_1D( filename, forcing%nCO2_inverse_history, 'CO2_inverse_history',  forcing%CO2_inverse_history)
       CALL write_to_field_history_dp_1D( filename, forcing%ndT_glob_history,     'dT_glob_history',      forcing%dT_glob_history)
     END IF
-    
+
     IF (C%choice_forcing_method == 'd18O_inverse_dT_glob') THEN
-      IF (.NOT.(PRESENT( forcing))) CALL crash('write_to_restart_file_grid needs forcing field if d18O_inverse_dT_glob is used')    
+      IF (.NOT.(PRESENT( forcing))) CALL crash('write_to_restart_file_grid needs forcing field if d18O_inverse_dT_glob is used')
       CALL write_to_field_history_dp_1D( filename, forcing%ndT_glob_inverse_history, 'dT_glob_inverse_history' , forcing%dT_glob_inverse_history)
     END IF
-    
+
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 
@@ -2183,12 +2183,12 @@ CONTAINS
     CALL permute_2D_dp( d_grid, wd_grid, map = [2,1])
     CALL write_var_dp_2D( filename, id_var_lon, d_grid)
     CALL deallocate_shared(wd_grid)
-    
+
     ! lat
     CALL add_field_grid_dp_2D_notime( filename, get_first_option_from_list( field_name_options_lat), long_name = 'Latitude', units = 'degrees north')
     CALL inquire_var_multiple_options( filename, field_name_options_lat, id_var_lat)
     CALL allocate_shared_dp_2D( grid%ny, grid%nx, d_grid, wd_grid)
-    d_grid( :, grid%i1:grid%i2) = grid%lon( :,grid%i1:grid%i2)
+    d_grid( :, grid%i1:grid%i2) = grid%lat( :,grid%i1:grid%i2)
     CALL sync
     CALL permute_2D_dp( d_grid, wd_grid, map = [2,1])
     CALL write_var_dp_2D( filename, id_var_lat, d_grid)
@@ -2683,7 +2683,7 @@ CONTAINS
     INTEGER                                            :: ntime_history
 
     ! Number of time history
-    ntime_history = SIZE(time_history,1) 
+    ntime_history = SIZE(time_history,1)
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -2703,7 +2703,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE add_time_history_dimension_to_file
-  
+
   SUBROUTINE add_month_dimension_to_file( filename)
     ! Add a month dimension and variable to an existing NetCDF file
 

--- a/src/netcdf_output_module.f90
+++ b/src/netcdf_output_module.f90
@@ -100,6 +100,12 @@ CONTAINS
       CALL crash('unknown choice_SMB_model "' // TRIM(C%choice_SMB_model) // '"!')
     END IF
 
+    ! Climate matrix
+    IF (C%choice_climate_model == 'matrix') THEN
+       CALL write_to_field_dp_0D( filename, 'w_EXT',   region%climate%matrix%w_EXT)
+       CALL write_to_field_dp_0D( filename, 'w_tot_P', region%climate%matrix%w_tot_P)
+    END IF
+
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 
@@ -163,7 +169,6 @@ CONTAINS
     CALL write_to_field_dp_0D( filename, 'tcomp_thermo',  global_data%tcomp_thermo)
     CALL write_to_field_dp_0D( filename, 'tcomp_climate', global_data%tcomp_climate)
     CALL write_to_field_dp_0D( filename, 'tcomp_GIA',     global_data%tcomp_GIA)
-
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)
@@ -275,6 +280,12 @@ CONTAINS
        CALL add_field_dp_0D( filename, 'runoff',     long_name='Ice-sheet integrated runoff', units='Gigaton yr^-1')
     ELSE
       CALL crash('unknown choice_SMB_model "' // TRIM(C%choice_SMB_model) // '"!')
+    END IF
+
+    ! Climate matrix
+    IF (C%choice_climate_model == 'matrix') THEN
+       CALL add_field_dp_0D( filename, 'w_EXT',   long_name='Weight factor from external forcing (CO2 + QTOA)', units='N/A')
+       CALL add_field_dp_0D( filename, 'w_tot_P', long_name='Weigth factor for precipitation from total topography change', units='N/A')
     END IF
 
     ! Finalise routine path
@@ -690,6 +701,18 @@ CONTAINS
     ELSEIF (field_name == 'GCM_PI_Precip') THEN
       CALL add_field_grid_dp_2D_monthly( filename, 'PI_Precip', long_name = 'Ref PI monthly total precipitation', units='mm')
 
+    ! Climate matrix
+    ELSEIF (field_name == 'w_ice_T') THEN
+      CALL add_field_grid_dp_2D( filename, 'w_ice_T', long_name = 'Temperature weight factor based on regional albedo and insolation', units='N/A')
+    ELSEIF (field_name == 'w_ins_T') THEN
+      CALL add_field_grid_dp_2D( filename, 'w_ins_T', long_name = 'Temperature weight factor based on local absorbed insolation', units='N/A')
+    ELSEIF (field_name == 'w_tot_T') THEN
+      CALL add_field_grid_dp_2D( filename, 'w_tot_T', long_name = 'Temperature weight factor based on local absorbed insolation', units='N/A')
+    ELSEIF (field_name == 'w_warm_P') THEN
+      CALL add_field_grid_dp_2D( filename, 'w_warm_P', long_name = 'Precipitation weight factor contribution from GCM_warm snapshot', units='N/A')
+    ELSEIF (field_name == 'w_cold_P') THEN
+      CALL add_field_grid_dp_2D( filename, 'w_cold_P', long_name = 'Precipitation weight factor contribution from GCM_cold snapshot', units='N/A')
+
     ! Forcing oceans
     ELSEIF (field_name == 'GCM_Warm_T_ocean_3D') THEN
       CALL add_field_grid_dp_3D_notime( filename, 'Warm_T_ocean_3D',    long_name='Warm 3-D ocean temperature', units='K')
@@ -961,16 +984,16 @@ CONTAINS
     ! ================
 
     ! Geometry
-    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, field_name_options_Hi , region%ice%Hi_a )
-    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, field_name_options_Hb , region%ice%Hb_a )
-    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, field_name_options_Hs , region%ice%Hs_a )
+    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, get_first_option_from_list(field_name_options_Hi)  , region%ice%Hi_a )
+    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, get_first_option_from_list(field_name_options_Hb)  , region%ice%Hb_a )
+    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, get_first_option_from_list(field_name_options_Hs)  , region%ice%Hs_a )
 
     ! Thermodynamics
-    CALL write_to_field_multiple_options_grid_dp_3D( filename, region%grid, field_name_options_Ti , region%ice%Ti_a )
+    CALL write_to_field_multiple_options_grid_dp_3D( filename, region%grid, get_first_option_from_list(field_name_options_Ti)  , region%ice%Ti_a )
 
     ! GIA
-    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, field_name_options_SL , region%ice%SL_a )
-    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, field_name_options_dHb, region%ice%dHb_a )
+    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, get_first_option_from_list(field_name_options_SL)  , region%ice%SL_a )
+    CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, get_first_option_from_list(field_name_options_dHb) , region%ice%dHb_a )
 
     ! Velocities
     IF     (C%choice_ice_dynamics == 'SIA/SSA') THEN
@@ -1165,6 +1188,18 @@ CONTAINS
       CALL write_to_field_multiple_options_grid_dp_2D_monthly( filename, region%grid, 'PI_T2m', region%climate%matrix%GCM_PI%T2m)
     ELSEIF (field_name == 'GCM_PI_Precip') THEN
       CALL write_to_field_multiple_options_grid_dp_2D_monthly( filename, region%grid, 'PI_Precip', region%climate%matrix%GCM_PI%Precip)
+      
+    ! Climate matrix
+    ELSEIF (field_name == 'w_ice_T') THEN
+      CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, 'w_ice_T', region%climate%matrix%w_ice_T)
+    ELSEIF (field_name == 'w_ins_T') THEN
+      CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, 'w_ins_T', region%climate%matrix%w_ins_T)
+    ELSEIF (field_name == 'w_tot_T') THEN
+      CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, 'w_tot_T', region%climate%matrix%w_tot_T)
+    ELSEIF (field_name == 'w_warm_P') THEN
+      CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, 'w_warm_P', region%climate%matrix%w_warm_P)
+    ELSEIF (field_name == 'w_cold_P') THEN
+      CALL write_to_field_multiple_options_grid_dp_2D( filename, region%grid, 'w_cold_P', region%climate%matrix%w_cold_P)
 
     ! Forcing oceans
     ELSEIF (field_name == 'GCM_Warm_T_ocean_3D') THEN

--- a/src/ocean_module.f90
+++ b/src/ocean_module.f90
@@ -1790,10 +1790,6 @@ CONTAINS
     CALL map_glob_to_grid_3D( ocean_glob%grid%nlat, ocean_glob%grid%nlon, ocean_glob%grid%lat, ocean_glob%grid%lon, hires%grid, ocean_glob%T_ocean, hires%T_ocean)
     CALL map_glob_to_grid_3D( ocean_glob%grid%nlat, ocean_glob%grid%nlon, ocean_glob%grid%lat, ocean_glob%grid%lon, hires%grid, ocean_glob%S_ocean, hires%S_ocean)
 
-    ! Permute the i and j dimensions to account for some weird orientation issue during mapping
-    CALL permute_3D_dp( hires%T_ocean, hires%wT_ocean, map = [1,3,2])
-    CALL permute_3D_dp( hires%S_ocean, hires%wS_ocean, map = [1,3,2])
-
     ! ===== Perform the extrapolation on the high-resolution grid =====
     ! =================================================================
 

--- a/src/utilities_module.f90
+++ b/src/utilities_module.f90
@@ -1983,7 +1983,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE transpose_dp_3D
-  
+
   SUBROUTINE transpose_int_2D( d, wd)
     ! Transpose a data field (i.e. go from [i,j] to [j,i] indexing or the other way round)
 
@@ -3183,7 +3183,7 @@ CONTAINS
     ! Clean up after yourself
     CALL deallocate_shared( grid%wnx         )
     CALL deallocate_shared( grid%wny         )
-	CALL deallocate_shared( grid%wn          )
+	  CALL deallocate_shared( grid%wn          )
     CALL deallocate_shared( grid%wx          )
     CALL deallocate_shared( grid%wy          )
     CALL deallocate_shared( grid%wdx         )
@@ -3191,9 +3191,6 @@ CONTAINS
     CALL deallocate_shared( grid%wxmax       )
     CALL deallocate_shared( grid%wymin       )
     CALL deallocate_shared( grid%wymax       )
-    CALL deallocate_shared( grid%wtol_dist   )
-    CALL deallocate_shared( grid%wij2n       )
-    CALL deallocate_shared( grid%wn2ij       )
     CALL deallocate_shared( grid%wlambda_m   )
     CALL deallocate_shared( grid%wphi_m      )
     CALL deallocate_shared( grid%wbeta_stereo)


### PR DESCRIPTION
Mainly updates to the Climate Matrix method as well as some bug fixes to improve glacial cycle simulations.

- Many improvements to the climate matrix method. Mainly to ensure the correct interpolation is used in regions with or without ice.

- You can choose a file to import ice and land masks used in the climate matrix. These are important as you need, for example, a reference albedo that is based on these masks.

- It is now possible to combine CO2 and Summer 65N insolation to drive temperature. This substantially improves the modelled glacial cycles.

- The inverse CO2 method works! The model can now change CO2 to match prescribed d18O concentrations.

TO DO (Only relevant for those running glacial cycles!)
- A config file containing a Last Glacial Cycle set-up. This requires a little bit more tuning and testing, but will be added shortly!

- Paleo-Antarctica and Greenland set-ups. (Wish me luck!)