### PR TITLE
Apply prescribed 3D ocean temperature field from a file

### DIFF
--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -477,7 +477,7 @@ MODULE configuration_module
   ! Climate
   ! =======
 
-  CHARACTER(LEN=256)  :: choice_climate_model_config                 = 'matrix_warm_cold'               ! Choice of climate model: "none", "idealised", "PD_obs", "PD_dTglob", "matrix_warm_cold", "direct_global", "direct_regional"
+  CHARACTER(LEN=256)  :: choice_climate_model_config                 = 'matrix_warm_cold'               ! Choice of climate model: "none", "idealised", "PD_obs", "PD_dTglob", "matrix_warm_cold", "direct_global", "direct_regional", "direct"
   CHARACTER(LEN=256)  :: choice_idealised_climate_config             = 'EISMINT1_A'
 
   ! Folder with NetCDF files containing direct climate forcing
@@ -534,7 +534,7 @@ MODULE configuration_module
   ! Ocean
   ! =====
 
-  CHARACTER(LEN=256)  :: choice_ocean_model_config                   = 'matrix_warm_cold'               ! Choice of ocean model: "none", "idealised", "uniform_warm_cold", "PD_obs", "matrix_warm_cold"
+  CHARACTER(LEN=256)  :: choice_ocean_model_config                   = 'matrix_warm_cold'               ! Choice of ocean model: "none", "idealised", "uniform_warm_cold", "PD_obs", "matrix_warm_cold", "prescribed_oceanT", "anomalies"
   CHARACTER(LEN=256)  :: choice_idealised_ocean_config               = 'MISMIP+_warm'                   ! Choice of idealised ocean: 'MISMIP+_warm', 'MISMIP+_cold', 'MISOMIP1', 'Reese2018_ANT'
 
   ! Delta ocean temperature inversion

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -552,6 +552,9 @@ MODULE configuration_module
   CHARACTER(LEN=256)  :: name_ocean_temperature_obs_config           = 't_an' ! E.g. objectively analysed mean (t_an) or statistical mean (t_mn)
   CHARACTER(LEN=256)  :: name_ocean_salinity_obs_config              = 's_an' ! E.g. objectively analysed mean (s_an) or statistical mean (s_mn)
 
+  ! NetCDF file containing the prescribed ocean temperature (NetCDF)
+  CHARACTER(LEN=256)  :: filename_prescribed_oceanT_config           = '/Users/berends/Documents/Datasets/Inverted_ocean_temperature.nc'
+
   ! GCM snapshots in the matrix_warm_cold option
   CHARACTER(LEN=256)  :: filename_GCM_ocean_snapshot_PI_config       = '/Users/berends/Documents/Datasets/COSMOS_ocean_examples/COSMOS_PI_oceanTS_prep.nc'
   CHARACTER(LEN=256)  :: filename_GCM_ocean_snapshot_warm_config     = '/Users/berends/Documents/Datasets/COSMOS_ocean_examples/COSMOS_PI_oceanTS_prep.nc'
@@ -1375,6 +1378,9 @@ MODULE configuration_module
     CHARACTER(LEN=256)                  :: filename_PD_obs_ocean
     CHARACTER(LEN=256)                  :: name_ocean_temperature_obs
     CHARACTER(LEN=256)                  :: name_ocean_salinity_obs
+
+    ! NetCDF file containing the prescribed ocean temperature (NetCDF)
+    CHARACTER(LEN=256)                  :: filename_prescribed_oceanT
 
     ! GCM snapshots in the matrix_warm_cold option
     CHARACTER(LEN=256)                  :: filename_GCM_ocean_snapshot_PI
@@ -2263,6 +2269,7 @@ CONTAINS
                      filename_PD_obs_ocean_config,                    &
                      name_ocean_temperature_obs_config,               &
                      name_ocean_salinity_obs_config,                  &
+                     filename_prescribed_oceanT_config,               &
                      filename_GCM_ocean_snapshot_PI_config,           &
                      filename_GCM_ocean_snapshot_warm_config,         &
                      filename_GCM_ocean_snapshot_cold_config,         &
@@ -3163,6 +3170,9 @@ CONTAINS
     C%filename_PD_obs_ocean                    = filename_PD_obs_ocean_config
     C%name_ocean_temperature_obs               = name_ocean_temperature_obs_config
     C%name_ocean_salinity_obs                  = name_ocean_salinity_obs_config
+
+    ! NetCDF file containing the prescribed ocean temperature (NetCDF)
+    C%filename_prescribed_oceanT               = filename_prescribed_oceanT_config
 
     ! GCM snapshots in the matrix_warm_cold option
     C%filename_GCM_ocean_snapshot_PI           = filename_GCM_ocean_snapshot_PI_config

--- a/src/ocean_module.f90
+++ b/src/ocean_module.f90
@@ -73,10 +73,10 @@ CONTAINS
 
       CALL run_ocean_model_PD_obs( grid, ocean_matrix)
 
-    ELSEIF (C%choice_ocean_model == 'prescribed') THEN
+    ELSEIF (C%choice_ocean_model == 'prescribed_oceanT') THEN
       ! Keep the ocean fixed to prescribed ocean temperature and present-day observed salinity
 
-      CALL run_ocean_model_prescribed( grid, ocean_matrix)
+      CALL run_ocean_model_prescribed_oceanT( grid, ocean_matrix)
 
     ELSEIF (C%choice_ocean_model == 'matrix_warm_cold') THEN
       ! Run the warm/cold ocean matrix
@@ -132,11 +132,11 @@ CONTAINS
 
       CALL initialise_ocean_model_PD_obs_regional( region, ocean_matrix_global)
 
-    ELSEIF (C%choice_ocean_model == 'prescribed') THEN
+    ELSEIF (C%choice_ocean_model == 'prescribed_oceanT') THEN
       ! Allocate both the "PD_obs" and "applied" snapshots, and initialise the present-day observations
 
       CALL initialise_ocean_model_PD_obs_regional( region, ocean_matrix_global)
-      CALL initialise_ocean_model_prescribed_regional( region)
+      CALL initialise_ocean_model_prescribed_oceanT_regional( region)
 
     ELSEIF (C%choice_ocean_model == 'matrix_warm_cold') THEN
       ! Allocate all the snapshots used in the warm/cold ocean matrix
@@ -185,7 +185,7 @@ CONTAINS
 
       CALL initialise_ocean_PD_obs_global( ocean_matrix%PD_obs, name = 'WOA18')
 
-    ELSEIF (C%choice_ocean_model == 'prescribed') THEN
+    ELSEIF (C%choice_ocean_model == 'prescribed_oceanT') THEN
       ! Initialise the "PD_obs" global snapshot so that salinity can be used. Temperature will be overwritten later.
 
       CALL initialise_ocean_PD_obs_global( ocean_matrix%PD_obs, name = 'WOA18')
@@ -1024,7 +1024,7 @@ CONTAINS
 ! == Static prescribed ocean temperature with present-day observed salinity
 ! ====================================
 
-  SUBROUTINE run_ocean_model_prescribed( grid, ocean_matrix)
+  SUBROUTINE run_ocean_model_prescribed_oceanT( grid, ocean_matrix)
     ! Run the regional ocean model
     !
     ! Just use the present-day observed ocean data
@@ -1036,7 +1036,7 @@ CONTAINS
     TYPE(type_ocean_matrix_regional),    INTENT(INOUT) :: ocean_matrix
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'run_ocean_model_prescribed'
+    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'run_ocean_model_prescribed_oceanT'
     INTEGER                                            :: i,j,k
 
     ! Add routine to path
@@ -1059,8 +1059,8 @@ CONTAINS
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 
-  END SUBROUTINE run_ocean_model_prescribed
-  SUBROUTINE initialise_ocean_model_prescribed_regional(region)
+  END SUBROUTINE run_ocean_model_prescribed_oceanT
+  SUBROUTINE initialise_ocean_model_prescribed_oceanT_regional(region)
     ! Initialise the regional ocean temperature from a file.
 
     IMPLICIT NONE
@@ -1069,7 +1069,7 @@ CONTAINS
     TYPE(type_model_region),             INTENT(INOUT) :: region
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'initialise_ocean_model_prescribed_regional'
+    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'initialise_ocean_model_prescribed_oceanT_regional'
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -1086,7 +1086,7 @@ CONTAINS
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)
-  END SUBROUTINE initialise_ocean_model_prescribed_regional
+  END SUBROUTINE initialise_ocean_model_prescribed_oceanT_regional
 
 ! == Ocean matrix with warm and cold snapshots
 ! ============================================


### PR DESCRIPTION
This merge contains the new option "prescribed" for choice_ocean_model_config. Using this option will read a file (give filename at filename_prescribed_oceanT_config) with a 3D ocean temperature field (name variable T_ocean). The temperature is kept constant over the run unless an ocean temperature inversion is turned on. The salinity is taken from the world ocean atlas (present day observed).

This option is for example useful if you want to do a simulation with a constant ocean temperature that is not present day observed. Or if you want to spinup with the inverted ocean temperature from another spinup as the starting point.