### PR TITLE
Climate matrix fixes and flow extrapolation

### DIFF
--- a/src/bedrock_module.f90
+++ b/src/bedrock_module.f90
@@ -101,8 +101,8 @@ CONTAINS
     CALL sync
 
     ! Calculate the relative surface load on the ice model grid
-    DO i = grid_GIA%i1, grid_GIA%i2
-    DO j = 1, grid_GIA%ny
+    DO i = grid%i1, grid%i2
+    DO j = 1, grid%ny
       ice%surface_load_rel( j,i) = surface_load_icemodel_grid( j,i) - ice%surface_load_topo( j,i)
     END DO
     END DO

--- a/src/climate_module.f90
+++ b/src/climate_module.f90
@@ -1748,7 +1748,7 @@ CONTAINS
     CALL inquire_var_multiple_options( filename, 'Wind_LR', found_wind_LR)
     CALL inquire_var_multiple_options( filename, 'Wind_DU', found_wind_DU)
 
-	! Check if South-North / East-West winds exist
+    ! Check if South-North / East-West winds exist
     IF (found_wind_WE /= -1 .AND. found_wind_SN /= -1) THEN
          found_winds = .TRUE.
     ELSE
@@ -1851,7 +1851,9 @@ CONTAINS
 
     ! Estimate the albedo from the climate snapshots based on the topography
     IF (C%reference_mask_method == 'estimate') THEN
-
+   
+      CALL warning('reference_mask_method "estimate" likely does not work. I recommend using setting "file" or fixing it.') 
+      
       DO i = grid%i1, grid%i2
       DO j = 1, grid%ny
 

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -503,7 +503,7 @@ MODULE configuration_module
   CHARACTER(LEN=256)  :: filename_climate_snapshot_cold_config       = '/Users/berends/Documents/Datasets/GCM_snapshots/Singarayer_Valdes_2010_LGM.nc'
 
   ! Ice and ocean mask from GCM snapshots
-  CHARACTER(LEN=256)  :: reference_mask_method_config                = 'estimate'                        ! 'estimate' (based on GCM topography and temperature) or 'file' from a selected file
+  CHARACTER(LEN=256)  :: reference_mask_method_config                = 'file'                        ! 'estimate' (based on GCM topography and temperature) or 'file' from a selected file
 
   CHARACTER(LEN=256)  :: filename_snapshot_mask_PD_obs_config        = ''
   CHARACTER(LEN=256)  :: filename_snapshot_mask_GCM_PI_config        = ''


### PR DESCRIPTION
This merge contains a few changes to the climate matrix, and the flow line extrapolation

New feature: 
- Jorjo's flowline extrapolation has been added to the model. Currently it is not being called, but someone else may find it of use.

Fixes / changes:
- Climate matrix reference albedo will not treat shelves as ice-free ocean anymore
- PI/PD temperature after bias correction now perfectly matches PD_obs
- Creating a climate snapshot ice mask based on topography may not work. I created a warning, and made sure that the default setting when creating climate snapshot ice masks is "file" instead of "estimate". 
- The topography differences in the climate matrix precipitation interpolation will now skip noice (read no ice) regions.
- For now, when creating the external forcing index, the Northern and Southern Hemisphere will both use 65N insolation.
- The relative surface load was computed over the GIA grid and not over the ice model grid when ELRA is used in the bedrock module. This is fixed now.
