### PR TITLE
Issue/restartspinup

### DIFF
--- a/src/IMAU_ICE_main_model.f90
+++ b/src/IMAU_ICE_main_model.f90
@@ -96,8 +96,6 @@ CONTAINS
       IF (par%master) dt_ave = dt_ave + region%dt
       CALL sync
       CALL determine_actions( region)
-      IF (par%master) print*, 'time = ',region%time !cvc
-      IF (par%master) print*, 'dt = ',region%dt !cvc
 
     ! GIA
     ! ===

--- a/src/IMAU_ICE_main_model.f90
+++ b/src/IMAU_ICE_main_model.f90
@@ -96,6 +96,8 @@ CONTAINS
       IF (par%master) dt_ave = dt_ave + region%dt
       CALL sync
       CALL determine_actions( region)
+      IF (par%master) print*, 'time = ',region%time !cvc
+      IF (par%master) print*, 'dt = ',region%dt !cvc
 
     ! GIA
     ! ===
@@ -451,7 +453,7 @@ CONTAINS
     CALL run_isotopes_model( region)
 
     ! GIA
-    IF (C%do_read_velocities_from_restart) THEN
+    IF (C%do_restart) THEN
       ! Do nothing
     ELSE
       IF     (C%choice_GIA_model == 'none') THEN
@@ -468,10 +470,10 @@ CONTAINS
       ELSE
         CALL crash('unknown choice_GIA_model "' // TRIM(C%choice_GIA_model) // '"!')
       END IF
-    END IF ! (C%do_read_velocities_from_restart) THEN
+    END IF ! (C%do_restart) THEN
 
-    ! Set do_read_velocities_from_restart to false so that velocities will be computed after initialisation of the restart
-    C%do_read_velocities_from_restart = .FAlSE.
+    ! Set do_restart to false so that velocities will be computed after initialisation of the restart
+    C%do_restart = .FAlSE.
 
     ! ===== Scalar output (regionally integrated ice volume, SMB components, etc.)
     ! ============================================================================
@@ -594,13 +596,23 @@ CONTAINS
       region%dt                    = C%dt_min
       region%dt_prev               = C%dt_min
 
-      region%t_last_SIA            = C%start_time_of_run
-      region%t_next_SIA            = C%start_time_of_run
-      region%do_SIA                = .TRUE.
+      IF (.NOT. C%do_restart_from_previous_timestep) THEN
+        region%t_last_SIA            = C%start_time_of_run
+        region%t_next_SIA            = C%start_time_of_run + C%dt_min
+        region%do_SIA                = .TRUE.
 
-      region%t_last_SSA            = C%start_time_of_run
-      region%t_next_SSA            = C%start_time_of_run
-      region%do_SSA                = .TRUE.
+        region%t_last_SSA            = C%start_time_of_run
+        region%t_next_SSA            = C%start_time_of_run + C%dt_min
+        region%do_SSA                = .TRUE.
+      ELSE
+        region%t_last_SIA            = C%start_time_of_run
+        region%t_next_SIA            = C%start_time_of_run
+        region%do_SIA                = .TRUE.
+
+        region%t_last_SSA            = C%start_time_of_run
+        region%t_next_SSA            = C%start_time_of_run
+        region%do_SSA                = .TRUE.
+      END IF
 
       region%t_last_DIVA           = C%start_time_of_run
       region%t_next_DIVA           = C%start_time_of_run

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -330,7 +330,8 @@ MODULE configuration_module
   REAL(dp)            :: DIVA_SOR_omega_config                       = 1.3_dp                           ! DIVA SOR   solver - over-relaxation parameter
   REAL(dp)            :: DIVA_PETSc_rtol_config                      = 0.01_dp                          ! DIVA PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
   REAL(dp)            :: DIVA_PETSc_abstol_config                    = 2.5_dp                           ! DIVA PETSc solver - stop criterion, absolute difference
-  LOGICAL             :: do_read_velocities_from_restart_config      = .FALSE.                          ! Whether or not to read velocities from restart file to initialise model
+  LOGICAL             :: do_restart_config                           = .FALSE.                          ! Whether or not to restart from restart file to initialise model
+  LOGICAL             :: do_restart_from_previous_timestep_config    = .FALSE.                          ! Whether or not to read timesteps from restart file to initialise model
 
   ! Ice dynamics - time integration
   ! ===============================
@@ -1163,7 +1164,9 @@ MODULE configuration_module
     REAL(dp)                            :: DIVA_SOR_omega
     REAL(dp)                            :: DIVA_PETSc_rtol
     REAL(dp)                            :: DIVA_PETSc_abstol
-    LOGICAL                             :: do_read_velocities_from_restart
+    LOGICAL                             :: do_restart
+    LOGICAL                             :: do_restart_from_previous_timestep
+
     ! Ice dynamics - time integration
     ! ===============================
 
@@ -2117,7 +2120,8 @@ CONTAINS
                      DIVA_SOR_omega_config,                           &
                      DIVA_PETSc_rtol_config,                          &
                      DIVA_PETSc_abstol_config,                        &
-                     do_read_velocities_from_restart_config,          &
+                     do_restart_config,                               &
+                     do_restart_from_previous_timestep_config,        &
                      choice_timestepping_config,                      &
                      choice_ice_integration_method_config,            &
                      dHi_choice_matrix_solver_config,                 &
@@ -2959,7 +2963,8 @@ CONTAINS
     C%DIVA_SOR_omega                           = DIVA_SOR_omega_config
     C%DIVA_PETSc_rtol                          = DIVA_PETSc_rtol_config
     C%DIVA_PETSc_abstol                        = DIVA_PETSc_abstol_config
-    C%do_read_velocities_from_restart          = do_read_velocities_from_restart_config
+    C%do_restart                               = do_restart_config
+    C%do_restart_from_previous_timestep        = do_restart_from_previous_timestep_config
 
     ! Ice dynamics - time integration
     ! ===============================

--- a/src/ice_dynamics_module.f90
+++ b/src/ice_dynamics_module.f90
@@ -125,7 +125,7 @@ CONTAINS
 
     ! Calculate ice velocities with the selected ice-dynamical approximation
     ! ======================================================================
-    IF (C%do_read_velocities_from_restart) THEN
+    IF (C%do_restart) THEN
     ! Do nothing, velocities are read from the restart file
     ELSE
       IF     (C%choice_ice_dynamics == 'none') THEN
@@ -288,7 +288,7 @@ CONTAINS
     ! Determine whether or not we need to update ice velocities
     do_update_ice_velocity = .FALSE.
 
-    IF (C%do_read_velocities_from_restart) THEN
+    IF (C%do_restart) THEN
       ! If restart, do not update ice_velocity but only the timers. Velocities are read from the restart file.
       IF     (C%choice_ice_dynamics == 'SIA') THEN
         IF (par%master) region%t_last_SIA = region%time
@@ -1032,7 +1032,7 @@ CONTAINS
       t_next = MIN( t_next, region%t_next_output_regional_scalar)
 
       ! Set time step so that we move forward to the next action
-      IF (C%do_read_velocities_from_restart) THEN
+      IF (C%do_restart) THEN
         ! do nothing, dt is read from restart file
       ELSE
         region%dt = t_next - region%time
@@ -1195,7 +1195,7 @@ CONTAINS
     CALL sync
 
     ! if restart, intialise dHi_dt and dHb_dt from restart file.
-    IF (C%do_read_velocities_from_restart) THEN
+    IF (C%do_restart) THEN
       CALL initialise_changing_geometry_from_restart_file( grid, ice, region_name)
     END IF
 
@@ -1246,7 +1246,7 @@ CONTAINS
     IF (is_ISMIP_HOM) CALL initialise_ice_velocity_ISMIP_HOM( grid, ice)
 
     ! Read velocity fields from restart data
-    IF (C%do_read_velocities_from_restart) THEN
+    IF (C%do_restart) THEN
       CALL initialise_velocities_from_restart_file( region, grid, ice, region_name)
     END IF
 

--- a/src/ice_velocity_module.f90
+++ b/src/ice_velocity_module.f90
@@ -246,7 +246,6 @@ CONTAINS
 
     ! Calculate secondary velocities (surface, base, etc.)
     CALL calc_secondary_velocities( grid, ice)
-    IF (par%master) print*, 'uabs_surf_a = ',SUM(ice%uabs_surf_a)!CvC
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)

--- a/src/ice_velocity_module.f90
+++ b/src/ice_velocity_module.f90
@@ -246,6 +246,7 @@ CONTAINS
 
     ! Calculate secondary velocities (surface, base, etc.)
     CALL calc_secondary_velocities( grid, ice)
+    IF (par%master) print*, 'uabs_surf_a = ',SUM(ice%uabs_surf_a)!CvC
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)
@@ -3116,14 +3117,20 @@ CONTAINS
       time_to_restart_from = C%time_to_restart_from_ANT
     END IF
 
-    CALL read_field_from_file_0D(   filename_restart, 'dt',          region%dt,          time_to_restart_from)
+    IF (C%do_restart_from_previous_timestep) THEN
+      CALL read_field_from_file_0D(   filename_restart, 'dt',          region%dt,          time_to_restart_from)
+    END IF ! (C%do_read_velocities_from_spinup) THEN
 
     IF (C%choice_ice_dynamics == 'SIA') THEN
-      CALL read_field_from_file_0D(   filename_restart, 't_next_SIA',          region%t_next_SIA,          time_to_restart_from)
-      CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SIA', region%dt_crit_SIA, time_to_restart_from)
+      IF (C%do_restart_from_previous_timestep) THEN
+        CALL read_field_from_file_0D(   filename_restart, 't_next_SIA',          region%t_next_SIA,          time_to_restart_from)
+        CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SIA', region%dt_crit_SIA, time_to_restart_from)
+      END IF ! (C%do_restart_from_previous_timestep) THEN
     ELSEIF (C%choice_ice_dynamics == 'SSA') THEN
-      CALL read_field_from_file_0D(   filename_restart, 't_next_SSA',          region%t_next_SSA,          time_to_restart_from)
-      CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SSA', region%dt_crit_SSA, time_to_restart_from)
+      IF (C%do_restart_from_previous_timestep) THEN
+        CALL read_field_from_file_0D(   filename_restart, 't_next_SSA',          region%t_next_SSA,          time_to_restart_from)
+        CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SSA', region%dt_crit_SSA, time_to_restart_from)
+      END IF ! (C%do_restart_from_previous_timestep) THEN
       u_SSA_cx_a = 0._dp
       v_SSA_cy_a = 0._dp
       CALL read_field_from_file_2D(   filename_restart, 'u_SSA_cx', grid,  u_SSA_cx_a,  region_name, time_to_restart_from)
@@ -3143,10 +3150,12 @@ CONTAINS
         ice%v_SSA_cy = v_SSA_cy_a(1:grid%ny-1, :)
       END IF
       CALL sync
-      CALL read_field_from_file_0D(   filename_restart, 't_next_SIA',          region%t_next_SIA,          time_to_restart_from)
-      CALL read_field_from_file_0D(   filename_restart, 't_next_SSA',          region%t_next_SSA,          time_to_restart_from)
-      CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SIA', region%dt_crit_SIA, time_to_restart_from)
-      CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SSA', region%dt_crit_SSA, time_to_restart_from)
+      IF (C%do_restart_from_previous_timestep) THEN
+        CALL read_field_from_file_0D(   filename_restart, 't_next_SIA',          region%t_next_SIA,          time_to_restart_from)
+        CALL read_field_from_file_0D(   filename_restart, 't_next_SSA',          region%t_next_SSA,          time_to_restart_from)
+        CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SIA',         region%dt_crit_SIA, time_to_restart_from)
+        CALL read_field_from_file_0D(   filename_restart, 'dt_crit_SSA',         region%dt_crit_SSA, time_to_restart_from)
+      END IF ! (C%do_restart_from_previous_timestep) THEN
     ELSEIF (C%choice_ice_dynamics == 'DIVA') THEN
       CALL read_field_from_file_3D(   filename_restart, 'visc_eff_3D', grid,  ice%visc_eff_3D_a,  region_name, time_to_restart_from)
       taub_cx_a = 0._dp
@@ -3158,12 +3167,17 @@ CONTAINS
         ice%taub_cy = taub_cy_a(1:grid%ny-1, :)
       END IF
       CALL sync
-      CALL read_field_from_file_0D(   filename_restart, 't_next_DIVA',          region%t_next_DIVA,          time_to_restart_from)
+      IF (C%do_restart_from_previous_timestep) THEN
+        CALL read_field_from_file_0D(   filename_restart, 't_next_DIVA',          region%t_next_DIVA,          time_to_restart_from)
+      END IF ! (C%do_restart_from_previous_timestep) THEN
+
     END IF ! IF (C%choice_ice_dynamics == 'SIA') THEN
 
     IF (C%choice_timestepping == 'pc') THEN
       CALL read_field_from_file_2D(   filename_restart, 'dHidt_Hn_un', grid,  ice%dHidt_Hn_un,  region_name, time_to_restart_from)
-      CALL read_field_from_file_0D(   filename_restart, 'dt_crit_ice', region%dt_crit_ice, time_to_restart_from)
+      IF (C%do_restart_from_previous_timestep) THEN
+        CALL read_field_from_file_0D(   filename_restart, 'dt_crit_ice', region%dt_crit_ice, time_to_restart_from)
+      END IF ! (C%do_restart_from_previous_timestep) THEN
       CALL read_field_from_file_0D(   filename_restart, 'pc_eta',      ice%pc_eta,      time_to_restart_from)
       CALL read_field_from_file_0D(   filename_restart, 'pc_eta_prev', ice%pc_eta_prev, time_to_restart_from)
     ELSEIF (C%choice_timestepping == 'direct') THEN


### PR DESCRIPTION
There is now 1 general flag "do_restart_config" that should be set to true when a restart run is required.

There are two types of restarting. One type is to restart from a spinup. In that case, no additional flags are needed. The other type is to restart from a continuous simulation, for example the last run was from 2024 to 2034 and the restart run is from 2034 to 2044. Set the new config variable "do_restart_from_previous_timestep_config" to TRUE if this is the case.

These config variables replace the config variable "do_read_velocities_from_restart". 