### PR TITLE
Config options for four ice sheets, mass balance fixes

### DIFF
--- a/src/IMAU_ICE_main_model.f90
+++ b/src/IMAU_ICE_main_model.f90
@@ -437,7 +437,10 @@ CONTAINS
     ! Initialise the rheology
     CALL calc_ice_rheology( region%grid, region%ice, C%start_time_of_run)
 
-    IF (C%choice_initial_ice_temperature == 'restart') THEN
+    IF ((region%name == 'NAM' .AND. C%choice_initial_ice_temperature_NAM == 'restart') .OR. &
+       ( region%name == 'EAS' .AND. C%choice_initial_ice_temperature_EAS == 'restart') .OR. &
+       ( region%name == 'GRL' .AND. C%choice_initial_ice_temperature_GRL == 'restart') .OR. &
+       ( region%name == 'ANT' .AND. C%choice_initial_ice_temperature_ANT == 'restart')) THEN
       ! Do nothing
     ELSE
       ! Run thermodynamics
@@ -495,7 +498,7 @@ CONTAINS
 
     IF (C%choice_ice_dynamics == 'none') THEN
       C%choice_ice_dynamics = 'DIVA'
-      CALL solve_DIVA( region%grid, region%ice)
+      CALL solve_DIVA( region%grid, region%ice, region%name)
       C%choice_ice_dynamics = 'none'
     END IF
 

--- a/src/IMAU_ICE_main_model.f90
+++ b/src/IMAU_ICE_main_model.f90
@@ -167,7 +167,7 @@ CONTAINS
 
       ! Run the BMB model
       IF (region%do_BMB) THEN
-        CALL run_BMB_model( region%grid, region%ice, region%ocean_matrix%applied, region%BMB, region%name, region%time, region%refgeo_PD)
+        CALL run_BMB_model( region%grid, region%ice, region%ocean_matrix%applied, region%BMB, region%name, region%time, region%refgeo_PD, region%climate)
       END IF
 
       t2 = MPI_WTIME()
@@ -429,7 +429,7 @@ CONTAINS
 
     ! Run ocean and BMB models once so that Hi can be computed at the beginning of the main model loop
     CALL run_ocean_model( region%grid, region%ice, region%ocean_matrix, region%climate, region%name, C%start_time_of_run, region%refgeo_PD)
-    CALL run_BMB_model( region%grid, region%ice, region%ocean_matrix%applied, region%BMB, region%name, C%start_time_of_run, region%refgeo_PD)
+    CALL run_BMB_model( region%grid, region%ice, region%ocean_matrix%applied, region%BMB, region%name, C%start_time_of_run, region%refgeo_PD, region%climate)
 
     ! Initialise the ice temperature field
     CALL initialise_ice_temperature( region%grid, region%ice, region%climate, region%ocean_matrix%applied, region%SMB, region%name)

--- a/src/basal_conditions_and_sliding_module.f90
+++ b/src/basal_conditions_and_sliding_module.f90
@@ -445,7 +445,17 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Determine filename
-    filename = C%basal_roughness_filename
+    IF (    region_name == 'NAM') THEN
+      filename = C%basal_roughness_filename_NAM
+    ELSEIF (region_name == 'EAS') THEN
+      filename = C%basal_roughness_filename_EAS
+    ELSEIF (region_name == 'GRL') THEN
+      filename = C%basal_roughness_filename_GRL
+    ELSEIF (region_name == 'ANT') THEN
+      filename = C%basal_roughness_filename_ANT
+    ELSE
+      CALL crash('region_name "'//TRIM(region_name)//'" not found!')
+    END IF
 
     IF (par%master) WRITE(0,*) '  Initialising basal roughness from file ', TRIM( filename), '...'
     CALL sync
@@ -483,7 +493,17 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Determine filename
-    filename = C%basal_roughness_filename
+    IF (    region_name == 'NAM') THEN
+      filename = C%basal_roughness_filename_NAM
+    ELSEIF (region_name == 'EAS') THEN
+      filename = C%basal_roughness_filename_EAS
+    ELSEIF (region_name == 'GRL') THEN
+      filename = C%basal_roughness_filename_GRL
+    ELSEIF (region_name == 'ANT') THEN
+      filename = C%basal_roughness_filename_ANT
+    ELSE
+      CALL crash('region_name "'//TRIM(region_name)//'" not found!')
+    END IF
 
     IF (par%master) WRITE(0,*) '  Initialising basal roughness from file ', TRIM( filename), '...'
     CALL sync
@@ -535,7 +555,17 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Determine filename
-    filename = C%basal_roughness_filename
+    IF (    region_name == 'NAM') THEN
+      filename = C%basal_roughness_filename_NAM
+    ELSEIF (region_name == 'EAS') THEN
+      filename = C%basal_roughness_filename_EAS
+    ELSEIF (region_name == 'GRL') THEN
+      filename = C%basal_roughness_filename_GRL
+    ELSEIF (region_name == 'ANT') THEN
+      filename = C%basal_roughness_filename_ANT
+    ELSE
+      CALL crash('region_name "'//TRIM(region_name)//'" not found!')
+    END IF
 
     IF (par%master) WRITE(0,*) '  Initialising basal roughness from file ', TRIM( filename), '...'
     CALL sync
@@ -572,7 +602,17 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Determine filename
-    filename = C%basal_roughness_filename
+    IF (    region_name == 'NAM') THEN
+      filename = C%basal_roughness_filename_NAM
+    ELSEIF (region_name == 'EAS') THEN
+      filename = C%basal_roughness_filename_EAS
+    ELSEIF (region_name == 'GRL') THEN
+      filename = C%basal_roughness_filename_GRL
+    ELSEIF (region_name == 'ANT') THEN
+      filename = C%basal_roughness_filename_ANT
+    ELSE
+      CALL crash('region_name "'//TRIM(region_name)//'" not found!')
+    END IF
 
     IF (par%master) WRITE(0,*) '  Initialising basal roughness from file ', TRIM( filename), '...'
     CALL sync
@@ -611,7 +651,17 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Determine filename
-    filename = C%basal_roughness_filename
+    IF (    region_name == 'NAM') THEN
+      filename = C%basal_roughness_filename_NAM
+    ELSEIF (region_name == 'EAS') THEN
+      filename = C%basal_roughness_filename_EAS
+    ELSEIF (region_name == 'GRL') THEN
+      filename = C%basal_roughness_filename_GRL
+    ELSEIF (region_name == 'ANT') THEN
+      filename = C%basal_roughness_filename_ANT
+    ELSE
+      CALL crash('region_name "'//TRIM(region_name)//'" not found!')
+    END IF
 
     IF (par%master) WRITE(0,*) '  Initialising basal roughness from file ', TRIM( filename), '...'
     CALL sync

--- a/src/calving_module.f90
+++ b/src/calving_module.f90
@@ -78,7 +78,8 @@ CONTAINS
     DO i = grid%i1, grid%i2
     DO j = 1, grid%ny
       IF (ice%mask_cf_a( j,i) == 1 .AND. ice%mask_shelf_a( j,i) == 1 .AND. ice%Hi_eff_cf_a( j,i) < C%calving_threshold_thickness) THEN
-        ice%Hi_a( j,i) = 0._dp
+        ice%Calving( j,i) = ice%Calving( j,i) - ice%Hi_a( j,i) ! Add the ice thickness to the calving rate
+        ice%Hi_a( j,i)    = 0._dp          ! Remove ice
       END IF
     END DO
     END DO

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -397,7 +397,10 @@ MODULE configuration_module
 
   ! Basal hydrology
   CHARACTER(LEN=256)  :: choice_basal_hydrology_config               = 'Martin2011'                     ! Choice of basal conditions: "saturated", "Martin2011"
-  REAL(dp)            :: Martin2011_hydro_N_lim_config               = 0.96_dp                          ! Martin et al. (2011) basal hydrology model: limit pore water pressure w.r.t. overburden [1=100% allowed; 0=no hydrology; 0.96 used in ref. paper]
+  REAL(dp)            :: Martin2011_hydro_N_lim_NAM_config           = 0.96_dp                          ! Martin et al. (2011) basal hydrology model: limit pore water pressure w.r.t. overburden [1=100% allowed; 0=no hydrology; 0.96 used in ref. paper]
+  REAL(dp)            :: Martin2011_hydro_N_lim_EAS_config           = 0.96_dp                          ! Martin et al. (2011) basal hydrology model: limit pore water pressure w.r.t. overburden [1=100% allowed; 0=no hydrology; 0.96 used in ref. paper]
+  REAL(dp)            :: Martin2011_hydro_N_lim_GRL_config           = 0.96_dp                          ! Martin et al. (2011) basal hydrology model: limit pore water pressure w.r.t. overburden [1=100% allowed; 0=no hydrology; 0.96 used in ref. paper]
+  REAL(dp)            :: Martin2011_hydro_N_lim_ANT_config           = 0.96_dp                          ! Martin et al. (2011) basal hydrology model: limit pore water pressure w.r.t. overburden [1=100% allowed; 0=no hydrology; 0.96 used in ref. paper]
   REAL(dp)            :: Martin2011_hydro_Hb_min_config              = 0._dp                            ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
   REAL(dp)            :: Martin2011_hydro_Hb_max_config              = 1000._dp                         ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
 
@@ -1237,7 +1240,10 @@ MODULE configuration_module
 
     ! Basal hydrology
     CHARACTER(LEN=256)                  :: choice_basal_hydrology
-    REAL(dp)                            :: Martin2011_hydro_N_lim
+    REAL(dp)                            :: Martin2011_hydro_N_lim_NAM
+    REAL(dp)                            :: Martin2011_hydro_N_lim_EAS
+    REAL(dp)                            :: Martin2011_hydro_N_lim_GRL
+    REAL(dp)                            :: Martin2011_hydro_N_lim_ANT
     REAL(dp)                            :: Martin2011_hydro_Hb_min
     REAL(dp)                            :: Martin2011_hydro_Hb_max
 
@@ -2180,7 +2186,10 @@ CONTAINS
                      deltaT_basal_freezing_config,                    &
                      subgrid_friction_exponent_config,                &
                      choice_basal_hydrology_config,                   &
-                     Martin2011_hydro_N_lim_config,                   &
+                     Martin2011_hydro_N_lim_NAM_config,               &
+                     Martin2011_hydro_N_lim_EAS_config,               &
+                     Martin2011_hydro_N_lim_GRL_config,               &
+                     Martin2011_hydro_N_lim_ANT_config,               &
                      Martin2011_hydro_Hb_min_config,                  &
                      Martin2011_hydro_Hb_max_config,                  &
                      choice_basal_roughness_config,                   &
@@ -3048,7 +3057,10 @@ CONTAINS
 
     ! Basal hydrology
     C%choice_basal_hydrology                   = choice_basal_hydrology_config
-    C%Martin2011_hydro_N_lim                   = Martin2011_hydro_N_lim_config
+    C%Martin2011_hydro_N_lim_NAM               = Martin2011_hydro_N_lim_NAM_config
+    C%Martin2011_hydro_N_lim_EAS               = Martin2011_hydro_N_lim_EAS_config
+    C%Martin2011_hydro_N_lim_GRL               = Martin2011_hydro_N_lim_GRL_config
+    C%Martin2011_hydro_N_lim_ANT               = Martin2011_hydro_N_lim_ANT_config
     C%Martin2011_hydro_Hb_min                  = Martin2011_hydro_Hb_min_config
     C%Martin2011_hydro_Hb_max                  = Martin2011_hydro_Hb_max_config
 
@@ -3066,9 +3078,9 @@ CONTAINS
     C%Martin2011till_phi_min                   = Martin2011till_phi_min_config
     C%Martin2011till_phi_max                   = Martin2011till_phi_max_config
     C%basal_roughness_filename_NAM             = basal_roughness_filename_NAM_config
-    C%basal_roughness_filename_EAS			   = basal_roughness_filename_EAS_config
-    C%basal_roughness_filename_GRL			   = basal_roughness_filename_GRL_config
-    C%basal_roughness_filename_ANT			   = basal_roughness_filename_ANT_config
+    C%basal_roughness_filename_EAS             = basal_roughness_filename_EAS_config
+    C%basal_roughness_filename_GRL             = basal_roughness_filename_GRL_config
+    C%basal_roughness_filename_ANT             = basal_roughness_filename_ANT_config
     C%do_smooth_phi_restart                    = do_smooth_phi_restart_config
     C%r_smooth_phi_restart                     = r_smooth_phi_restart_config
     C%porenudge_H_dHdt_flowline_dist_max       = porenudge_H_dHdt_flowline_dist_max_config

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -469,7 +469,10 @@ MODULE configuration_module
   ! Thermodynamics and rheology
   ! ===========================
 
-  CHARACTER(LEN=256)  :: choice_initial_ice_temperature_config       = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "restart"
+  CHARACTER(LEN=256)  :: choice_initial_ice_temperature_NAM_config   = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "restart"
+  CHARACTER(LEN=256)  :: choice_initial_ice_temperature_EAS_config   = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "restart"
+  CHARACTER(LEN=256)  :: choice_initial_ice_temperature_GRL_config   = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "restart"
+  CHARACTER(LEN=256)  :: choice_initial_ice_temperature_ANT_config   = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "restart"
   REAL(dp)            :: uniform_ice_temperature_config              = 270._dp                          ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
   CHARACTER(LEN=256)  :: choice_thermo_model_config                  = '3D_heat_equation'               ! Choice of thermodynamical model: "none", "3D_heat_equation"
   CHARACTER(LEN=256)  :: choice_ice_rheology_config                  = 'Huybrechts1992'                 ! Choice of ice rheology model: "uniform", "Huybrechts1992", "MISMIP_mod"
@@ -1306,7 +1309,10 @@ MODULE configuration_module
     ! Thermodynamics and rheology
     ! ===========================
 
-    CHARACTER(LEN=256)                  :: choice_initial_ice_temperature
+    CHARACTER(LEN=256)                  :: choice_initial_ice_temperature_NAM
+    CHARACTER(LEN=256)                  :: choice_initial_ice_temperature_EAS
+    CHARACTER(LEN=256)                  :: choice_initial_ice_temperature_GRL
+    CHARACTER(LEN=256)                  :: choice_initial_ice_temperature_ANT
     REAL(dp)                            :: uniform_ice_temperature
     CHARACTER(LEN=256)                  :: choice_thermo_model
     CHARACTER(LEN=256)                  :: choice_ice_rheology
@@ -2234,7 +2240,10 @@ CONTAINS
                      remove_shelves_larger_than_PD_config,            &
                      continental_shelf_calving_config,                &
                      continental_shelf_min_height_config,             &
-                     choice_initial_ice_temperature_config,           &
+                     choice_initial_ice_temperature_NAM_config,       &
+                     choice_initial_ice_temperature_EAS_config,       &
+                     choice_initial_ice_temperature_GRL_config,       &
+                     choice_initial_ice_temperature_ANT_config,       &
                      uniform_ice_temperature_config,                  &
                      choice_thermo_model_config,                      &
                      choice_ice_rheology_config,                      &
@@ -3111,7 +3120,10 @@ CONTAINS
     ! Thermodynamics and rheology
     ! ===========================
 
-    C%choice_initial_ice_temperature           = choice_initial_ice_temperature_config
+    C%choice_initial_ice_temperature_NAM       = choice_initial_ice_temperature_NAM_config
+    C%choice_initial_ice_temperature_EAS       = choice_initial_ice_temperature_EAS_config
+    C%choice_initial_ice_temperature_GRL       = choice_initial_ice_temperature_GRL_config
+    C%choice_initial_ice_temperature_ANT       = choice_initial_ice_temperature_ANT_config
     C%uniform_ice_temperature                  = uniform_ice_temperature_config
     C%choice_thermo_model                      = choice_thermo_model_config
     C%choice_ice_rheology                      = choice_ice_rheology_config

--- a/src/configuration_module.f90
+++ b/src/configuration_module.f90
@@ -414,7 +414,10 @@ MODULE configuration_module
   REAL(dp)            :: Martin2011till_phi_Hb_max_config            = 0._dp                            ! Martin et al. (2011) bed roughness model: high-end Hb  value of bedrock-dependent till friction angle
   REAL(dp)            :: Martin2011till_phi_min_config               = 5._dp                            ! Martin et al. (2011) bed roughness model: low-end  phi value of bedrock-dependent till friction angle
   REAL(dp)            :: Martin2011till_phi_max_config               = 20._dp                           ! Martin et al. (2011) bed roughness model: high-end phi value of bedrock-dependent till friction angle
-  CHARACTER(LEN=256)  :: basal_roughness_filename_config             = ''                               ! NetCDF file containing a basal roughness field for the chosen sliding law
+  CHARACTER(LEN=256)  :: basal_roughness_filename_NAM_config         = ''                               ! NetCDF file containing a basal roughness field for the chosen sliding law
+  CHARACTER(LEN=256)  :: basal_roughness_filename_EAS_config         = ''                               ! NetCDF file containing a basal roughness field for the chosen sliding law
+  CHARACTER(LEN=256)  :: basal_roughness_filename_GRL_config         = ''                               ! NetCDF file containing a basal roughness field for the chosen sliding law
+  CHARACTER(LEN=256)  :: basal_roughness_filename_ANT_config         = ''                               ! NetCDF file containing a basal roughness field for the chosen sliding law
   LOGICAL             :: do_smooth_phi_restart_config                = .FALSE.                          ! Whether or not to smooth the prescribed bed roughness once (crucial for downscaling runs)
   REAL(dp)            :: r_smooth_phi_restart_config                 = 0.5_dp                           ! Prescribed bed roughness smoothing radius (in number of grid cells)
   REAL(dp)            :: porenudge_H_dHdt_flowline_dist_max_config   = 500.0_dp                          ! Maximum distance for flowline extrapolation (km)
@@ -1248,7 +1251,10 @@ MODULE configuration_module
     REAL(dp)                            :: Martin2011till_phi_Hb_max
     REAL(dp)                            :: Martin2011till_phi_min
     REAL(dp)                            :: Martin2011till_phi_max
-    CHARACTER(LEN=256)                  :: basal_roughness_filename
+    CHARACTER(LEN=256)                  :: basal_roughness_filename_NAM
+    CHARACTER(LEN=256)                  :: basal_roughness_filename_EAS
+    CHARACTER(LEN=256)                  :: basal_roughness_filename_GRL
+    CHARACTER(LEN=256)                  :: basal_roughness_filename_ANT
     LOGICAL                             :: do_smooth_phi_restart
     REAL(dp)                            :: r_smooth_phi_restart
     REAL(dp)                            :: porenudge_H_dHdt_flowline_dist_max
@@ -2183,7 +2189,10 @@ CONTAINS
                      Martin2011till_phi_Hb_max_config,                &
                      Martin2011till_phi_min_config,                   &
                      Martin2011till_phi_max_config,                   &
-                     basal_roughness_filename_config,                 &
+                     basal_roughness_filename_NAM_config,             &
+                     basal_roughness_filename_EAS_config,             &
+                     basal_roughness_filename_GRL_config,             &
+                     basal_roughness_filename_ANT_config,             &
                      do_smooth_phi_restart_config,                    &
                      r_smooth_phi_restart_config,                     &
                      porenudge_H_dHdt_flowline_dist_max_config,       &
@@ -3047,7 +3056,10 @@ CONTAINS
     C%Martin2011till_phi_Hb_max                = Martin2011till_phi_Hb_max_config
     C%Martin2011till_phi_min                   = Martin2011till_phi_min_config
     C%Martin2011till_phi_max                   = Martin2011till_phi_max_config
-    C%basal_roughness_filename                 = basal_roughness_filename_config
+    C%basal_roughness_filename_NAM             = basal_roughness_filename_NAM_config
+    C%basal_roughness_filename_EAS			   = basal_roughness_filename_EAS_config
+    C%basal_roughness_filename_GRL			   = basal_roughness_filename_GRL_config
+    C%basal_roughness_filename_ANT			   = basal_roughness_filename_ANT_config
     C%do_smooth_phi_restart                    = do_smooth_phi_restart_config
     C%r_smooth_phi_restart                     = r_smooth_phi_restart_config
     C%porenudge_H_dHdt_flowline_dist_max       = porenudge_H_dHdt_flowline_dist_max_config

--- a/src/data_types_module.f90
+++ b/src/data_types_module.f90
@@ -292,7 +292,8 @@ MODULE data_types_module
     ! Ice dynamics - calving
     REAL(dp), DIMENSION(:,:  ), POINTER     :: float_margin_frac_a   ! Ice-covered fraction for calving front pixels
     REAL(dp), DIMENSION(:,:  ), POINTER     :: Hi_eff_cf_a           ! Effective ice thickness at calving front pixels (= Hi of thinnest non-calving-front neighbour)
-    INTEGER :: wfloat_margin_frac_a, wHi_eff_cf_a
+    REAL(dp), DIMENSION(:,:  ), POINTER     :: Calving               ! Total calving rate (m)
+    INTEGER :: wfloat_margin_frac_a, wHi_eff_cf_a, wCalving
 
     ! Ice dynamics - predictor/corrector ice thickness update
     REAL(dp),                   POINTER     :: pc_zeta
@@ -339,7 +340,8 @@ MODULE data_types_module
     REAL(dp), DIMENSION(:,:  ), POINTER     :: dHi_a                  ! Ice thickness difference w.r.t. PD reference
     REAL(dp), DIMENSION(:,:  ), POINTER     :: dHs_a                  ! Surface elevation difference w.r.t. PD reference
     REAL(dp), DIMENSION(:,:  ), POINTER     :: dHi_dt_target          ! Target dHi_dt during model spinup
-    INTEGER :: wdHi_a, wdHs_a, wdHi_dt_target
+    REAL(dp), DIMENSION(:,:  ), POINTER     :: MB                            ! Annual MB   (m)
+    INTEGER :: wdHi_a, wdHs_a, wdHi_dt_target, wMB
 
   END TYPE type_ice_model
 
@@ -711,6 +713,7 @@ MODULE data_types_module
     REAL(dp), DIMENSION(:,:  ), POINTER     :: Albedo_year                   ! Yearly albedo
     REAL(dp), DIMENSION(:,:,:), POINTER     :: SMB                           ! Monthly SMB (m)
     REAL(dp), DIMENSION(:,:  ), POINTER     :: SMB_year                      ! Yearly  SMB (m)
+
     INTEGER :: wAlbedoSUrf, wMeltPreviousYear, wFirnDepth, wMeltPreviousYearforrestart, wFirnDepthforrestart, wRainfall, wSnowfall, wAddedFirn, wMelt
     INTEGER :: wRefreezing, wRefreezing_year, wRunoff, wAlbedo, wAlbedo_year, wSMB, wSMB_year
 
@@ -1212,7 +1215,9 @@ MODULE data_types_module
     REAL(dp), POINTER                       :: int_SMB
     REAL(dp), POINTER                       :: int_BMB
     REAL(dp), POINTER                       :: int_MB
-    INTEGER :: wint_T2m, wint_snowfall, wint_rainfall, wint_melt, wint_refreezing, wint_runoff, wint_SMB, wint_BMB, wint_MB
+    REAL(dp), POINTER                       :: int_Calving
+    REAL(dp), POINTER                       :: int_dt
+    INTEGER :: wint_T2m, wint_snowfall, wint_rainfall, wint_melt, wint_refreezing, wint_runoff, wint_SMB, wint_BMB, wint_MB, wint_Calving, wint_dt
 
     ! Variables related to the englacial isotope content
     REAL(dp), POINTER                       :: mean_isotope_content

--- a/src/ice_velocity_module.f90
+++ b/src/ice_velocity_module.f90
@@ -116,7 +116,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE solve_SIA
-  SUBROUTINE solve_SSA(  grid, ice)
+  SUBROUTINE solve_SSA(  grid, ice, region_name)
     ! Calculate ice velocities using the SSA. Velocities are calculated on the staggered
     ! cx/cy-grids, using the discretisation scheme adopted from Yelmo/SICOPOLIS.
 
@@ -125,6 +125,7 @@ CONTAINS
     ! In- and output variables:
     TYPE(type_grid),                     INTENT(IN)    :: grid
     TYPE(type_ice_model),                INTENT(INOUT) :: ice
+    CHARACTER(LEN=3),                    INTENT(IN)    :: region_name
 
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'solve_SSA'
@@ -168,7 +169,7 @@ CONTAINS
     CALL sync
 
     ! Calculate the basal yield stress tau_c
-    CALL calc_basal_conditions( grid, ice)
+    CALL calc_basal_conditions( grid, ice, region_name)
 
     ! Determine sub-grid grounded fractions for scaling the basal friction
     CALL determine_grounded_fractions( grid, ice)
@@ -251,7 +252,7 @@ CONTAINS
     CALL finalise_routine( routine_name)
 
   END SUBROUTINE solve_SSA
-  SUBROUTINE solve_DIVA( grid, ice)
+  SUBROUTINE solve_DIVA( grid, ice, region_name)
     ! Calculate ice velocities using the DIVA. Velocities are calculated on the staggered
     ! cx/cy-grids, using the discretisation scheme adopted from Yelmo/SICOPOLIS.
 
@@ -260,6 +261,7 @@ CONTAINS
     ! In- and output variables:
     TYPE(type_grid),                     INTENT(IN)    :: grid
     TYPE(type_ice_model),                INTENT(INOUT) :: ice
+    CHARACTER(LEN=3),                    INTENT(IN)    :: region_name
 
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'solve_DIVA'
@@ -299,7 +301,7 @@ CONTAINS
     CALL sync
 
     ! Calculate the basal yield stress tau_c
-    CALL calc_basal_conditions( grid, ice)
+    CALL calc_basal_conditions( grid, ice, region_name)
 
     ! Determine sub-grid grounded fractions for scaling the basal friction
     CALL determine_grounded_fractions( grid, ice)

--- a/src/isotopes_module.f90
+++ b/src/isotopes_module.f90
@@ -180,11 +180,11 @@ CONTAINS
     DO j = 2, region%grid%ny-1
       IF (region%ice%mask_ice_a( j,i) == 1) THEN
 
-        ! Calculate advective isotope fluxes
+        ! Calculate IsoIce advection
         IF (region%ice%U_vav_cx( j  ,i-1) > 0._dp) THEN
-          dIso_xl = region%ice%U_vav_cx( j  ,i-1) * region%ice%Hi_a( j  ,i-1) * region%ice%IsoIce( j  ,i-1) * region%grid%dx
+          dIso_xl = region%ice%U_vav_cx( j  ,i-1) * region%ice%Hi_a(        j  ,i-1) * region%ice%IsoIce( j  ,i-1) * region%grid%dx
         ELSE
-          dIso_xl = region%ice%U_vav_cx( j  ,i-1) * region%ice%Hi_a( j  ,i  ) * region%ice%IsoIce( j  ,i  ) * region%grid%dx
+          dIso_xl = region%ice%U_vav_cx( j  ,i-1) * region%ice%Hi_a(        j  ,i  ) * region%ice%IsoIce( j  ,i  ) * region%grid%dx
         END IF
       
         IF (region%ice%U_vav_cx( j  ,i  ) > 0._dp) THEN
@@ -217,12 +217,12 @@ CONTAINS
         ! Calcualte the new IsoIce and limit it between IsoMin and IsoMax
         IsoIce_new( j,i) = MIN( IsoMax, MAX( IsoMin, VIso / (region%grid%dx * region%grid%dx * region%ice%Hi_tplusdt_a( j,i)) ))
        
-        ! FAIL SAVE: For very thin ice this calculation does not work. So assume IsoIce is 0.
+        ! FAIL SAVE: For very thin ice (e.g., <1E-50) this calculation does not work. So assume IsoIce is 0.
         IF (region%ice%Hi_tplusdt_a( j,i) < 0.1_dp) THEN
           IsoIce_new( j,i) = 0._dp
         END IF
 
-        ! FAIL SAVE: Calving front take the IsoIce from the source of advected ice
+        ! FAIL SAVE: Calving front take over IsoIce from neighbouring cell!
         IF (region%ice%float_margin_frac_a( j,i) < 0.99_dp) THEN
            
            ! Check the source areas:

--- a/src/netcdf_output_module.f90
+++ b/src/netcdf_output_module.f90
@@ -81,6 +81,7 @@ CONTAINS
     CALL write_to_field_dp_0D( filename, 'SMB',           region%int_SMB)
     CALL write_to_field_dp_0D( filename, 'BMB',           region%int_BMB)
     CALL write_to_field_dp_0D( filename, 'MB',            region%int_MB)
+    CALL write_to_field_dp_0D( filename, 'Calving',       region%int_Calving)
 
     ! Individual SMB components
     IF     (C%choice_SMB_model == 'uniform' .OR. &
@@ -263,9 +264,10 @@ CONTAINS
     CALL add_field_dp_0D( filename, 'ice_volume_af', long_name='Ice volume above flotation', units='m.s.l.e')
     CALL add_field_dp_0D( filename, 'ice_area',      long_name='Ice volume', units='km^2')
     CALL add_field_dp_0D( filename, 'T2m',           long_name='Regionally averaged annual mean surface temperature', units='K')
-    CALL add_field_dp_0D( filename, 'SMB',           long_name='Ice-sheet integrated surface mass balance', units='Gigaton yr^-1')
-    CALL add_field_dp_0D( filename, 'BMB',           long_name='Ice-sheet integrated basal mass balance', units='Gigaton yr^-1')
-    CALL add_field_dp_0D( filename, 'MB',            long_name='Ice-sheet integrated mass balance', units='Gigaton yr^-1')
+    CALL add_field_dp_0D( filename, 'SMB',           long_name='Ice-sheet integrated surface mass balance',           units='Gigaton yr^-1')
+    CALL add_field_dp_0D( filename, 'BMB',           long_name='Ice-sheet integrated basal mass balance',             units='Gigaton yr^-1')
+    CALL add_field_dp_0D( filename, 'MB',            long_name='Ice-sheet integrated mass balance',                   units='Gigaton yr^-1')
+    CALL add_field_dp_0D( filename, 'Calving',       long_name='Ice-sheet integrated calving',                        units='Gigaton yr^-1')
 
     ! Individual SMB components
     IF     (C%choice_SMB_model == 'uniform' .OR. &

--- a/src/thermodynamics_module.f90
+++ b/src/thermodynamics_module.f90
@@ -769,28 +769,43 @@ CONTAINS
     TYPE(type_SMB_model),                 INTENT(IN)    :: SMB
     CHARACTER(LEN=3),                     INTENT(IN)    :: region_name
 
+
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'initialise_ice_temperature'
+    CHARACTER(LEN=256)				                   :: choice_initial_ice_temperature
 
     ! Add routine to path
     CALL init_routine( routine_name)
+    
+    ! Get the right initial ice temperature method
+    IF (    region_name == 'NAM') THEN
+      choice_initial_ice_temperature = C%choice_initial_ice_temperature_NAM
+    ELSEIF (region_name == 'EAS') THEN
+      choice_initial_ice_temperature = C%choice_initial_ice_temperature_EAS
+    ELSEIF (region_name == 'GRL') THEN
+      choice_initial_ice_temperature = C%choice_initial_ice_temperature_GRL
+    ELSEIF (region_name == 'ANT') THEN
+      choice_initial_ice_temperature = C%choice_initial_ice_temperature_ANT
+    ELSE
+      CALL crash('region_name "'//TRIM(region_name)//'" not found!')
+    END IF
+    
+    IF (par%master) WRITE (0,*) '  Initialising ice temperature profile "', TRIM(choice_initial_ice_temperature), '"...'
 
-    IF (par%master) WRITE (0,*) '  Initialising ice temperature profile "', TRIM(C%choice_initial_ice_temperature), '"...'
-
-    IF     (C%choice_initial_ice_temperature == 'uniform') THEN
+    IF     (choice_initial_ice_temperature == 'uniform') THEN
       ! Simple uniform temperature
       CALL initialise_ice_temperature_uniform( grid, ice)
-    ELSEIF (C%choice_initial_ice_temperature == 'linear') THEN
+    ELSEIF (choice_initial_ice_temperature == 'linear') THEN
       ! Simple linear temperature profile
       CALL initialise_ice_temperature_linear( grid, ice, climate)
-    ELSEIF (C%choice_initial_ice_temperature == 'Robin') THEN
+    ELSEIF (choice_initial_ice_temperature == 'Robin') THEN
       ! Initialise with the Robin solution
       CALL initialise_ice_temperature_Robin( grid, ice, climate, ocean, SMB)
-    ELSEIF (C%choice_initial_ice_temperature == 'restart') THEN
+    ELSEIF (choice_initial_ice_temperature == 'restart') THEN
       ! Initialise with the temperature field from the provided restart file
       CALL initialise_ice_temperature_restart( grid, ice, region_name)
     ELSE
-      CALL crash('unknown choice_initial_ice_temperature "' // TRIM( C%choice_initial_ice_temperature) // '"!')
+      CALL crash('unknown choice_initial_ice_temperature "' // TRIM( Choice_initial_ice_temperature) // '"!')
     END IF
 
     ! Finalise routine path


### PR DESCRIPTION
Several bug fixes as well as a few improvements. Several configuration options were added so they can be set differently for each ice sheet, which helps people that simulate glacial cycles.

However, these configuration options does mean that users will need to change their config files to accommodate these changes! Otherwise the model will crash.

> List of fixes
- Refreezing is limited to the thickness of the firn layer. Without firn, there should be little to no refreezing. This means that the mass balance is going to be a little bit lower. I have not tested how much this will impact Antarctica.

- 1D mass balance component output should now work! More details below.

- Calving can be outputted as a 1D scalar!

- When using ANICE_Legacy BMB, ocean temperatures now follow the climate matrix method, rather than using two separate CO2/insolation parameterisations.

- The lapse rate in the isotope module has changed again. (It was originally wrong, then I made it correct a few months ago, to then make it wrong again. Now I am reasonably confident I have made it right again!) This results in less strongly negative d18O concentrations in the ice, which match reconstructions much better! There will be another isotope update in the future though, as deep water temperature needs to be fixed.

- The isotope module now works reasonably well for the calving front. It copies the d18O concentration of neighbouring ice source cells. Though not 100% (it's 99.99%) perfect, it is much more stable. As far as I know, there are no extreme d18O values in grid-cells anymore!

- The bias correction in the climate matrix method was resurrected. You can use the bias correction for cold snapshot once again. But I do not recommend it when the observed and GCM climate have large differences in resolution!
 
> More details on the Mass Balance
The scalar output mass balance works! The following fixes were needed:

- MB (mass balance) now perfectly aligns with the ice volume rate / total change in thickness. It keeps track of the total change in ice volume and converts it to Gigatons per year. The Mass Balance should be 100% correct.

- Calving is now also outputted. As long as developers make sure to add every bit of calved ice to the Calving 2D field, Calving should be 100% correct. 

- If SMB and BMB melt exceed the amount of ice available, they will be scaled with respect to the ice that is available.  Therefore, regions with very thin ice (e.g., 0.01 m) will not show up in the scalar output with strongly negative SMB/BMB (-10 m). However, there may be a small issue as ice could be added through advection, and the current method may not properly account for that.

- The Mass Balance now closes almost completely. (MB = SMB + BMB + Calving). For North America, I get a deviation of ~1-2 Gt/yr, which is less than 1% of the total mass balance.

- Caroline added an extra config variable: do_write_regional_scalar_output_average_config. When set to true, the model outputs the mean between two scalar outputs. Default is set to false so the output contains the exact value at the time of output.

Flaws:

- The mass balance does not account for ice leaving the domain. So the mass balance may not close at all if a lot of ice is being removed due to this. If you get shelf islands (shelves fully detached from grounded ice), this ice is removed. This ice is also not taken into account in the calving.
 
- There may be some tiny corrections / fluxes that are not accounted for.

> List of config options

Since I start from an ice-free North America and Eurasia, and a Greenland spin-up, I had no choice but to add a few config options:

- Ice temperature options for when starting a simulation:
Replacing: *choice_initial_ice_temperature*
choice_initial_ice_temperature_NAM
choice_initial_ice_temperature_EAS
choice_initial_ice_temperature_GRL
choice_initial_ice_temperature_ANT

- Replacing: *basal_roughness_filename*
basal_roughness_filename_NAM
basal_roughness_filename_EAS
basal_roughness_filename_GRL
basal_roughness_filename_ANT

- Replacing: * Martin2011_hydro_N_lim*
Martin2011_hydro_N_lim_NAM
Martin2011_hydro_N_lim_EAS
Martin2011_hydro_N_lim_GRL
Martin2011_hydro_N_lim_ANT
Perhaps a weird one. Though I noticed that North America, Eurasia and Greenland need a much stronger effect from hydrology compared to Antarctica.

> A couple things to note:
- Make sure to change your config file before running.

- SMB is lower due to the changes in refreezing.

- The mass balance does not close 100%. This is mostly due to some ice leaving the domain. Though there may be other sources that I am not aware of. For North America, the difference is only ~1% of the total mass balance. 

- Note that this change in mass balance scalar output is substantial. You can expect >75% lower mass balances in the output now! But the values are much more realistic.

- Note that the SMB and BMB 2D fields are not directly applied to the mass balance of the ice sheet. As BMB and SMB are limited by the floating margin fraction and the available ice. The 2D fields therefore should also be fixed. However, I highly recommend adding a separate SMB / BMB field (e.g., SMB applied), as people may be interested in these values for ice-free regions. 

- Calving and MB can theoretically be outputted as 2D fields. However, I have not tested this.

- If you add another Calving parametrisation, you should add the resulting change in thickness to the Calving variable. This is to make sure IMAU-ICE can keep track of the Calving mass balance.

- There may be a few extra config options in the future!

